### PR TITLE
PlatformがLinuxでない場合は SleepIntervalAdjustorのテストをスキップ

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,5 @@
 """This file contains helper objects for testing some features."""
+import platform
 from typing import Self
 
 import pytest
@@ -45,3 +46,7 @@ class DataBufferImpl(BaseDataBuffer):
 
     def make_dataset(self) -> TensorDataset:
         return TensorDataset(torch.stack(self.obs))
+
+
+def skip_if_platform_is_not_linux():
+    return pytest.mark.skipif(platform.system() != "Linux", reason="Platform is not linux.")

--- a/tests/interactions/test_fixed_interval_interaction.py
+++ b/tests/interactions/test_fixed_interval_interaction.py
@@ -5,8 +5,11 @@ import pytest
 from ami.interactions.fixed_interval_interaction import FixedIntervalInteraction
 from ami.interactions.interval_adjustors import SleepIntervalAdjustor
 
+from ..helpers import skip_if_platform_is_not_linux
+
 
 class TestFixedIntervalInteraction:
+    @skip_if_platform_is_not_linux()
     @pytest.mark.parametrize("interval", [0.1])
     def test_intervals(self, mock_env, mock_agent, interval: float):
         interaction = FixedIntervalInteraction(

--- a/tests/interactions/test_interval_adustors.py
+++ b/tests/interactions/test_interval_adustors.py
@@ -8,6 +8,8 @@ from ami.interactions.interval_adjustors import (
     SleepIntervalAdjustor,
 )
 
+from ..helpers import skip_if_platform_is_not_linux
+
 
 def compute_adjustor_spec(adjustor: BaseIntervalAdjustor, num_trial: int) -> tuple[float, float]:
     """`num_trial`の回数だけ`adjust`を実行し，経過時間の平均と標準偏差を返す．"""
@@ -21,6 +23,7 @@ def compute_adjustor_spec(adjustor: BaseIntervalAdjustor, num_trial: int) -> tup
 
 
 class TestSleepIntervalAdjustor:
+    @skip_if_platform_is_not_linux()
     @pytest.mark.parametrize(
         """interval,num_trial""",
         [


### PR DESCRIPTION
## 概要

MacOSのローカル環境でテストする場合は `time.sleep`の精度が出ずテストが落ちるので`Linux`環境上のみでテストするように束縛．
https://github.com/MLShukai/ami/pull/39#issuecomment-1935333297

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
