### PR TITLE
`BaseAgent`に推論モデルとData Collectorをアタッチ

### DIFF
--- a/ami/interactions/agents/base_agent.py
+++ b/ami/interactions/agents/base_agent.py
@@ -37,7 +37,7 @@ class BaseAgent(ABC, Generic[ObsType, ActType]):
 
     def attach_data_collectors(self, data_collectors: DataCollectorsDict) -> None:
         """Attaches the data collectors (dict) to this agent."""
-        self._data_collectors = data_collectors
+        self.data_collectors = data_collectors
         self.on_data_collectors_attached()
 
     def on_data_collectors_attached(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import torch
 from ami.data.step_data import DataKeys, StepData
 from ami.data.utils import DataCollectorsDict, DataUsersDict
 from ami.models.model_wrapper import ModelWrapper
-from ami.models.utils import ModelWrappersDict
+from ami.models.utils import InferenceWrappersDict, ModelWrappersDict
 from tests.helpers import DataBufferImpl, ModelMultiplyP, get_gpu_device
 
 
@@ -32,6 +32,11 @@ def model_wrappers_dict(gpu_device: torch.device | None) -> ModelWrappersDict:
     )
     d.send_to_default_device()
     return d
+
+
+@pytest.fixture
+def inference_wrappers_dict(model_wrappers_dict: ModelWrappersDict) -> InferenceWrappersDict:
+    return model_wrappers_dict.inference_wrappers_dict
 
 
 @pytest.fixture

--- a/tests/interactions/agents/test_base_agent.py
+++ b/tests/interactions/agents/test_base_agent.py
@@ -1,0 +1,26 @@
+from ami.interactions.agents.base_agent import BaseAgent
+
+
+class AgentImpl(BaseAgent[str, str]):
+    def on_inference_models_attached(self) -> None:
+        self.model1 = self.get_inference_model("model1")
+
+    def on_data_collectors_attached(self) -> None:
+        self.data_collector1 = self.get_data_collector("buffer1")
+
+    def step(self, observation: str) -> str:
+        return "action"
+
+
+class TestBaseAgent:
+    def test_attach_inference_models(self, inference_wrappers_dict):
+        agent = AgentImpl()
+        agent.attach_inference_models(inference_wrappers_dict)
+
+        assert agent.model1
+
+    def test_attach_data_collectors(self, data_collectors_dict):
+        agent = AgentImpl()
+        agent.attach_data_collectors(data_collectors_dict)
+
+        assert agent.data_collector1


### PR DESCRIPTION
## 概要

Agent内部で推論モデルの取得やデータコレクタでデータを保存するために、そのオブジェクトをAgentにアタッチするメソッドを追加。アタッチ後のコールバックを設定。


**NOTE**: `BaseAgent.data_collectors`は全ての子`DataCollector`の`collect`メソッドを呼び出すメソッド`collect`を持つため、明示的に使える変数としてアンダーバーをつけていません。アンダーバーをつけても子クラスで問題なく使えるので、つけるべきであればそうします。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
