### PR TITLE
`TrainersList`クラスを追加

### DIFF
--- a/ami/trainers/utils.py
+++ b/ami/trainers/utils.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from ..data.utils import DataUsersDict
 from ..models.utils import ModelWrappersDict
 from .base_trainer import BaseTrainer

--- a/ami/trainers/utils.py
+++ b/ami/trainers/utils.py
@@ -1,0 +1,74 @@
+from typing import Any
+
+from ..data.utils import DataUsersDict
+from ..models.utils import ModelWrappersDict
+from .base_trainer import BaseTrainer
+
+
+class TrainersList(list[BaseTrainer]):
+    """A custom list class for aggregating trainers, designed for integration
+    within the `hydra` configuration framework.
+
+    This class facilitates the configuration and management of multiple trainer
+    instances in a unified manner, enabling sequential or conditional execution within
+    training workflows.
+
+    Example usage in a Hydra configuration file (`config.yaml`):
+
+        ```yaml
+        trainers:
+          _target_: <path.to>.TrainersList
+          - _target_: <path.to.trainer1>
+          - _target_: <path.to.trainer2>
+        ```
+
+    Usage in a `TrainingThread`:
+
+        ```python
+        class TrainingThread:
+            trainers: TrainersList
+
+            def worker(self):
+
+                while True:
+                    trainer = self.trainers.get_next_trainer()
+                    trainer.run()
+        ```
+    """
+
+    _current_index = 0
+
+    def get_next_trainer(self) -> BaseTrainer:
+        """Retrieves the next trainer instance in a round-robin fashion for
+        training.
+
+        Raises:
+            RuntimeError: If the TrainersList is empty, indicating there are no trainers to return.
+
+        Returns:
+            BaseTrainer: The next trainer instance in the list to be used for training.
+        """
+        if (length := len(self)) == 0:
+            raise RuntimeError("TrainersList is empty!")
+
+        trainer = self[self._current_index]
+        self._current_index = (self._current_index + 1) % length
+        return trainer
+
+    def attach_model_wrappers_dict(self, model_wrappers_dict: ModelWrappersDict) -> None:
+        """Attaches model wrappers to each trainer instance in the list.
+
+        Args:
+            model_wrappers_dict: A dictionary of model wrapper objects to be attached to trainers.
+        """
+        for trainer in self:
+            trainer.attach_model_wrappers_dict(model_wrappers_dict)
+
+    def attach_data_users_dict(self, data_users_dict: DataUsersDict) -> None:
+        """Attaches data users to each trainer instance in the list.
+
+        Args:
+            data_users_dict: A dictionary of data user objects to be attached to trainers.
+        """
+        for trainer in self:
+            trainer.attach_data_users_dict(data_users_dict)

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -6,10 +6,6 @@ from .test_base_trainer import TrainerImpl
 
 
 class TestTrainersList:
-    @pytest.fixture
-    def trainers(self, model_wrappers_dict, data_users_dict) -> TrainersList:
-        trainers = TrainersList([TrainerImpl(), TrainerImpl()])
-
     def test_get_next_trainer(self):
         trainer1 = TrainerImpl()
         trainer2 = TrainerImpl()

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -1,0 +1,40 @@
+import pytest
+
+from ami.trainers.utils import TrainersList
+
+from .test_base_trainer import TrainerImpl
+
+
+class TestTrainersList:
+    @pytest.fixture
+    def trainers(self, model_wrappers_dict, data_users_dict) -> TrainersList:
+        trainers = TrainersList([TrainerImpl(), TrainerImpl()])
+
+    def test_get_next_trainer(self):
+        trainer1 = TrainerImpl()
+        trainer2 = TrainerImpl()
+
+        trainers = TrainersList([trainer1, trainer2])
+
+        assert trainers.get_next_trainer() is trainer1
+        assert trainers.get_next_trainer() is trainer2
+        assert trainers.get_next_trainer() is trainer1
+        assert trainers.get_next_trainer() is trainer2
+
+    def test_attach_model_wrappers_dict(self, model_wrappers_dict):
+        trainer1 = TrainerImpl()
+        trainer2 = TrainerImpl()
+
+        trainers = TrainersList([trainer1, trainer2])
+        trainers.attach_model_wrappers_dict(model_wrappers_dict)
+        assert trainer1._model_wrappers_dict is model_wrappers_dict
+        assert trainer2._model_wrappers_dict is model_wrappers_dict
+
+    def test_attach_data_users_dict(self, data_users_dict):
+        trainer1 = TrainerImpl()
+        trainer2 = TrainerImpl()
+
+        trainers = TrainersList([trainer1, trainer2])
+        trainers.attach_data_users_dict(data_users_dict)
+        assert trainer1._data_users_dict is data_users_dict
+        assert trainer2._data_users_dict is data_users_dict

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -21,6 +21,10 @@ class TestTrainersList:
         assert trainers.get_next_trainer() is trainer1
         assert trainers.get_next_trainer() is trainer2
 
+        with pytest.raises(RuntimeError):
+            empty_trainers = TrainersList()
+            empty_trainers.get_next_trainer()
+
     def test_attach_model_wrappers_dict(self, model_wrappers_dict):
         trainer1 = TrainerImpl()
         trainer2 = TrainerImpl()


### PR DESCRIPTION
## 概要

Trainerを集約し、シーケンシャルに実行するためのクラスを追加。`TrainingThread`上で学習を無限実行するために用いる。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
