### PR TITLE
非同期排他制御のためのクラスに`ThreadSafe`プリフィクスを付与した。

### DIFF
--- a/ami/data/interfaces.py
+++ b/ami/data/interfaces.py
@@ -9,7 +9,7 @@ from .buffers.base_data_buffer import BaseDataBuffer
 from .step_data import StepData
 
 
-class DataCollector:
+class ThreadSafeDataCollector:
     """Collects the data in inference thread."""
 
     def __init__(self, buffer: BaseDataBuffer) -> None:
@@ -43,7 +43,7 @@ class DataCollector:
 class DataUser:
     """Uses the collected data in training thread."""
 
-    def __init__(self, collector: DataCollector) -> None:
+    def __init__(self, collector: ThreadSafeDataCollector) -> None:
         """Constructs the data user object."""
         self.collector = collector
         self._lock = threading.RLock()  # For data user is referred from multiple threads.

--- a/ami/data/interfaces.py
+++ b/ami/data/interfaces.py
@@ -40,7 +40,7 @@ class ThreadSafeDataCollector:
             return return_data
 
 
-class DataUser:
+class ThreadSafeDataUser:
     """Uses the collected data in training thread."""
 
     def __init__(self, collector: ThreadSafeDataCollector) -> None:

--- a/ami/data/utils.py
+++ b/ami/data/utils.py
@@ -19,7 +19,7 @@ Assumed usage:
 from typing import Self
 
 from .buffers.base_data_buffer import BaseDataBuffer
-from .interfaces import DataCollector, DataUser
+from .interfaces import DataUser, ThreadSafeDataCollector
 from .step_data import StepData
 
 
@@ -28,7 +28,7 @@ class DataUsersDict(dict[str, DataUser]):
     thread to the training thread."""
 
 
-class DataCollectorsDict(dict[str, DataCollector]):
+class DataCollectorsDict(dict[str, ThreadSafeDataCollector]):
     """A class for aggregating `DataCollectors` to invoke their `collect`
     methods within the agent class."""
 
@@ -44,7 +44,7 @@ class DataCollectorsDict(dict[str, DataCollector]):
         Args:
             **data_buffers: Key-value pairs of names and corresponding implemented DataBuffer objects.
         """
-        return cls({k: DataCollector(v) for k, v in data_buffers.items()})
+        return cls({k: ThreadSafeDataCollector(v) for k, v in data_buffers.items()})
 
     def get_data_users(self) -> DataUsersDict:
         """Creates a `DataUsersDict` from the item's value."""

--- a/ami/data/utils.py
+++ b/ami/data/utils.py
@@ -19,11 +19,11 @@ Assumed usage:
 from typing import Self
 
 from .buffers.base_data_buffer import BaseDataBuffer
-from .interfaces import DataUser, ThreadSafeDataCollector
+from .interfaces import ThreadSafeDataCollector, ThreadSafeDataUser
 from .step_data import StepData
 
 
-class DataUsersDict(dict[str, DataUser]):
+class DataUsersDict(dict[str, ThreadSafeDataUser]):
     """A class for aggregating `DataUsers` to share them from the inference
     thread to the training thread."""
 
@@ -48,4 +48,4 @@ class DataCollectorsDict(dict[str, ThreadSafeDataCollector]):
 
     def get_data_users(self) -> DataUsersDict:
         """Creates a `DataUsersDict` from the item's value."""
-        return DataUsersDict({k: DataUser(v) for k, v in self.items()})
+        return DataUsersDict({k: ThreadSafeDataUser(v) for k, v in self.items()})

--- a/ami/interactions/agents/base_agent.py
+++ b/ami/interactions/agents/base_agent.py
@@ -4,7 +4,7 @@ from typing import Generic
 
 import torch.nn as nn
 
-from ...data.utils import DataCollector, DataCollectorsDict
+from ...data.utils import DataCollectorsDict, ThreadSafeDataCollector
 from ...models.utils import InferenceWrapper, InferenceWrappersDict
 from .._types import ActType, ObsType
 
@@ -50,7 +50,7 @@ class BaseAgent(ABC, Generic[ObsType, ActType]):
             raise KeyError(f"The specified model name '{name}' does not exist.")
         return self._inference_models[name]
 
-    def get_data_collector(self, name: str) -> DataCollector:
+    def get_data_collector(self, name: str) -> ThreadSafeDataCollector:
         if name not in self.data_collectors:
             raise KeyError(f"The specified data collector name '{name}' does not exist.")
         return self.data_collectors[name]

--- a/ami/interactions/agents/base_agent.py
+++ b/ami/interactions/agents/base_agent.py
@@ -5,7 +5,7 @@ from typing import Generic
 import torch.nn as nn
 
 from ...data.utils import DataCollectorsDict, ThreadSafeDataCollector
-from ...models.utils import InferenceWrapper, InferenceWrappersDict
+from ...models.utils import InferenceWrappersDict, ThreadSafeInferenceWrapper
 from .._types import ActType, ObsType
 
 
@@ -45,7 +45,7 @@ class BaseAgent(ABC, Generic[ObsType, ActType]):
         agent."""
         pass
 
-    def get_inference_model(self, name: str) -> InferenceWrapper[nn.Module]:
+    def get_inference_model(self, name: str) -> ThreadSafeInferenceWrapper[nn.Module]:
         if name not in self._inference_models:
             raise KeyError(f"The specified model name '{name}' does not exist.")
         return self._inference_models[name]

--- a/ami/models/model_wrapper.py
+++ b/ami/models/model_wrapper.py
@@ -92,7 +92,7 @@ class ModelWrapper(nn.Module, Generic[ModuleType]):
             p.requires_grad = True
         self.train()
 
-    def create_inference(self) -> InferenceWrapper[ModuleType]:
+    def create_inference(self) -> ThreadSafeInferenceWrapper[ModuleType]:
         """Creates the inference wrapper for the inference thread.
 
         Do not call when the model wrapper has no inference model.
@@ -107,12 +107,12 @@ class ModelWrapper(nn.Module, Generic[ModuleType]):
         if self.has_inference:
             copied_self = copy.deepcopy(self)
             copied_self.freeze_model()
-            return InferenceWrapper(copied_self)
+            return ThreadSafeInferenceWrapper(copied_self)
 
         raise RuntimeError("The model has no inference component!")
 
 
-class InferenceWrapper(Generic[ModuleType]):
+class ThreadSafeInferenceWrapper(Generic[ModuleType]):
     """A wrapper class for performing inference with the model in a thread-safe
     manner.
 

--- a/ami/models/utils.py
+++ b/ami/models/utils.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 
 import torch.nn as nn
 
-from .model_wrapper import InferenceWrapper, ModelWrapper
+from .model_wrapper import ModelWrapper, ThreadSafeInferenceWrapper
 
 
 class ModelNames(StrEnum):
@@ -12,7 +12,7 @@ class ModelNames(StrEnum):
     IMAGE_ENCODER = "image_encoder"
 
 
-class InferenceWrappersDict(dict[str, InferenceWrapper[nn.Module]]):
+class InferenceWrappersDict(dict[str, ThreadSafeInferenceWrapper[nn.Module]]):
     """Aggregates inference wrapper classes to share models from the training
     thread to the inference thread."""
 

--- a/ami/trainers/base_trainer.py
+++ b/ami/trainers/base_trainer.py
@@ -4,7 +4,7 @@ from typing import Any, TypeAlias
 
 import torch.nn as nn
 
-from ..data.interfaces import DataUser
+from ..data.interfaces import ThreadSafeDataUser
 from ..data.utils import DataUsersDict
 from ..models.model_wrapper import ModelWrapper
 from ..models.utils import InferenceWrappersDict, ModelWrappersDict
@@ -134,7 +134,7 @@ class BaseTrainer(ABC):
         model.unfreeze_model()
         return model
 
-    def get_data_user(self, name: str) -> DataUser:
+    def get_data_user(self, name: str) -> ThreadSafeDataUser:
         """Retrieves the specified data user."""
         if name not in self._data_users_dict:
             raise KeyError(f"The specified data user name '{name}' does not exist.")

--- a/tests/data/test_interfaces.py
+++ b/tests/data/test_interfaces.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from ami.data.interfaces import DataCollector, DataUser
+from ami.data.interfaces import DataUser, ThreadSafeDataCollector
 from ami.data.step_data import DataKeys, StepData
 
 from .buffers.test_base_data_buffer import DataBufferImpl
@@ -9,11 +9,11 @@ from .buffers.test_base_data_buffer import DataBufferImpl
 
 class TestDataCollectorAndUser:
     @pytest.fixture
-    def collector(self) -> DataCollector:
-        return DataCollector(DataBufferImpl())
+    def collector(self) -> ThreadSafeDataCollector:
+        return ThreadSafeDataCollector(DataBufferImpl())
 
     @pytest.fixture
-    def user(self, collector: DataCollector) -> DataUser:
+    def user(self, collector: ThreadSafeDataCollector) -> DataUser:
         return DataUser(collector)
 
     @pytest.fixture
@@ -21,11 +21,11 @@ class TestDataCollectorAndUser:
         return StepData({DataKeys.OBSERVATION: torch.randn(10)})
 
     # --- Testing Collector ---
-    def test_collect(self, collector: DataCollector, step_data: StepData) -> None:
+    def test_collect(self, collector: ThreadSafeDataCollector, step_data: StepData) -> None:
 
         collector.collect(step_data)
 
-    def test_move_data(self, collector: DataCollector) -> None:
+    def test_move_data(self, collector: ThreadSafeDataCollector) -> None:
 
         buffer = collector._buffer
         moved_buffer = collector.move_data()
@@ -33,7 +33,7 @@ class TestDataCollectorAndUser:
         assert buffer is not collector._buffer
 
     # --- Testing User ---
-    def test_get_new_dataset(self, collector: DataCollector, user: DataUser, step_data: StepData) -> None:
+    def test_get_new_dataset(self, collector: ThreadSafeDataCollector, user: DataUser, step_data: StepData) -> None:
         collector.collect(step_data)
 
         dataset = user.get_new_dataset()
@@ -43,7 +43,7 @@ class TestDataCollectorAndUser:
         dataset = user.get_new_dataset()
         assert torch.equal(dataset[:][0], torch.stack([step_data[DataKeys.OBSERVATION]] * 2))
 
-    def test_clear(self, collector: DataCollector, user: DataUser, step_data: StepData) -> None:
+    def test_clear(self, collector: ThreadSafeDataCollector, user: DataUser, step_data: StepData) -> None:
         collector.collect(step_data)
 
         collector_buffer = collector._buffer

--- a/tests/data/test_interfaces.py
+++ b/tests/data/test_interfaces.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from ami.data.interfaces import DataUser, ThreadSafeDataCollector
+from ami.data.interfaces import ThreadSafeDataCollector, ThreadSafeDataUser
 from ami.data.step_data import DataKeys, StepData
 
 from .buffers.test_base_data_buffer import DataBufferImpl
@@ -13,8 +13,8 @@ class TestDataCollectorAndUser:
         return ThreadSafeDataCollector(DataBufferImpl())
 
     @pytest.fixture
-    def user(self, collector: ThreadSafeDataCollector) -> DataUser:
-        return DataUser(collector)
+    def user(self, collector: ThreadSafeDataCollector) -> ThreadSafeDataUser:
+        return ThreadSafeDataUser(collector)
 
     @pytest.fixture
     def step_data(self) -> StepData:
@@ -33,7 +33,9 @@ class TestDataCollectorAndUser:
         assert buffer is not collector._buffer
 
     # --- Testing User ---
-    def test_get_new_dataset(self, collector: ThreadSafeDataCollector, user: DataUser, step_data: StepData) -> None:
+    def test_get_new_dataset(
+        self, collector: ThreadSafeDataCollector, user: ThreadSafeDataUser, step_data: StepData
+    ) -> None:
         collector.collect(step_data)
 
         dataset = user.get_new_dataset()
@@ -43,7 +45,7 @@ class TestDataCollectorAndUser:
         dataset = user.get_new_dataset()
         assert torch.equal(dataset[:][0], torch.stack([step_data[DataKeys.OBSERVATION]] * 2))
 
-    def test_clear(self, collector: ThreadSafeDataCollector, user: DataUser, step_data: StepData) -> None:
+    def test_clear(self, collector: ThreadSafeDataCollector, user: ThreadSafeDataUser, step_data: StepData) -> None:
         collector.collect(step_data)
 
         collector_buffer = collector._buffer

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from ami.data.step_data import DataKeys, StepData
-from ami.data.utils import DataCollector, DataCollectorsDict, DataUsersDict
+from ami.data.utils import DataCollectorsDict, DataUsersDict, ThreadSafeDataCollector
 
 from .buffers.test_base_data_buffer import DataBufferImpl
 
@@ -13,15 +13,15 @@ class TestDataCollectorsDict:
         return DataBufferImpl()
 
     @pytest.fixture
-    def collector(self, buffer: DataBufferImpl) -> DataCollector:
-        return DataCollector(buffer)
+    def collector(self, buffer: DataBufferImpl) -> ThreadSafeDataCollector:
+        return ThreadSafeDataCollector(buffer)
 
     @pytest.fixture
     def step_data(self) -> StepData:
         return StepData({DataKeys.OBSERVATION: torch.randn(10)})
 
     @pytest.fixture
-    def collectors_dict(self, collector: DataCollector) -> DataCollectorsDict:
+    def collectors_dict(self, collector: ThreadSafeDataCollector) -> DataCollectorsDict:
         return DataCollectorsDict(a=collector)
 
     def test_collect(self, collectors_dict: DataCollectorsDict, step_data: StepData) -> None:
@@ -29,7 +29,7 @@ class TestDataCollectorsDict:
 
     def test_from_buffers(self, buffer: DataBufferImpl) -> None:
         collectors = DataCollectorsDict.from_data_buffers(b=buffer)
-        assert isinstance(collectors["b"], DataCollector)
+        assert isinstance(collectors["b"], ThreadSafeDataCollector)
 
     def test_get_data_users(self, collectors_dict: DataCollectorsDict) -> None:
         assert isinstance(collectors_dict.get_data_users(), DataUsersDict)

--- a/tests/models/test_model_wrapper.py
+++ b/tests/models/test_model_wrapper.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from ami.models.model_wrapper import InferenceWrapper, ModelWrapper
+from ami.models.model_wrapper import ModelWrapper, ThreadSafeInferenceWrapper
 from tests.helpers import ModelMultiplyP, skip_if_gpu_is_not_available
 
 
@@ -26,7 +26,7 @@ class TestWrappers:
         m = ModelMultiplyP()
         mw = ModelWrapper(m, "cpu", True)
         inference_wrapper = mw.create_inference()
-        assert isinstance(inference_wrapper, InferenceWrapper)
+        assert isinstance(inference_wrapper, ThreadSafeInferenceWrapper)
         assert inference_wrapper.model is not m
         assert inference_wrapper.model.p is not m.p
         assert inference_wrapper.model.p == m.p

--- a/tests/trainers/test_base_trainer.py
+++ b/tests/trainers/test_base_trainer.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn as nn
 
 from ami.data.utils import DataUsersDict
-from ami.models.model_wrapper import InferenceWrapper, ModelWrapper
+from ami.models.model_wrapper import ModelWrapper, ThreadSafeInferenceWrapper
 from ami.models.utils import ModelWrappersDict
 from tests.helpers import ModelMultiplyP, TrainerImpl
 
@@ -66,7 +66,7 @@ class TestTrainer:
 
     def test_sync_a_model(self, trainer: TrainerImpl) -> None:
         wrapper: ModelWrapper[ModelMultiplyP] = trainer._model_wrappers_dict["model1"]
-        inference: InferenceWrapper[ModelMultiplyP] = trainer._inference_wrappers_dict["model1"]
+        inference: ThreadSafeInferenceWrapper[ModelMultiplyP] = trainer._inference_wrappers_dict["model1"]
 
         wrapper.model.p.data += 1
         assert not torch.equal(wrapper.model.p, inference.model.p)


### PR DESCRIPTION
## 概要

#80 変更したクラス。

- InferenceWrapper -> ThreadSafeInferneceWrapper
- DataCollector -> ThreadSafeDataCollector
- DataUser -> ThreadSafeDataUser

## 影響範囲

多くのファイルに影響しているので他の作業が進んでいる場合に競合する恐れが大きい。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
