### PR TITLE
DataCollector/UserをDataBufferのGenericsにした

### DIFF
--- a/ami/data/interfaces.py
+++ b/ami/data/interfaces.py
@@ -66,3 +66,8 @@ class ThreadSafeDataUser(Generic[BufferType]):
         with self._lock:
             self._buffer = self._buffer.new()
             self.collector.renew()
+
+    @property
+    def buffer(self) -> BufferType:
+        """Returns the reference to the internal buffer."""
+        return self._buffer

--- a/ami/data/interfaces.py
+++ b/ami/data/interfaces.py
@@ -1,18 +1,20 @@
 """This file contains the interface class for a data buffer designed for multi-
 threading."""
 import threading
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from torch.utils.data import Dataset
 
 from .buffers.base_data_buffer import BaseDataBuffer
 from .step_data import StepData
 
+BufferType = TypeVar("BufferType", bound=BaseDataBuffer)
 
-class ThreadSafeDataCollector:
+
+class ThreadSafeDataCollector(Generic[BufferType]):
     """Collects the data in inference thread."""
 
-    def __init__(self, buffer: BaseDataBuffer) -> None:
+    def __init__(self, buffer: BufferType) -> None:
         """Constructs data collector class."""
         self._buffer = buffer
         self._lock = threading.RLock()
@@ -23,7 +25,7 @@ class ThreadSafeDataCollector:
             self._buffer.add(step_data)
 
     @property
-    def new_data_buffer(self) -> BaseDataBuffer:
+    def new_data_buffer(self) -> BufferType:
         """Returns renewed data buffer object."""
         return self._buffer.new()
 
@@ -32,7 +34,7 @@ class ThreadSafeDataCollector:
         with self._lock:
             self._buffer = self.new_data_buffer
 
-    def move_data(self) -> BaseDataBuffer:
+    def move_data(self) -> BufferType:
         """Move data's pointer to other object."""
         with self._lock:
             return_data = self._buffer
@@ -40,10 +42,10 @@ class ThreadSafeDataCollector:
             return return_data
 
 
-class ThreadSafeDataUser:
+class ThreadSafeDataUser(Generic[BufferType]):
     """Uses the collected data in training thread."""
 
-    def __init__(self, collector: ThreadSafeDataCollector) -> None:
+    def __init__(self, collector: ThreadSafeDataCollector[BufferType]) -> None:
         """Constructs the data user object."""
         self.collector = collector
         self._lock = threading.RLock()  # For data user is referred from multiple threads.

--- a/ami/data/utils.py
+++ b/ami/data/utils.py
@@ -17,19 +17,19 @@ Assumed usage:
     >>> collector = hydra.utils.instantiate(cfg)
 """
 from collections import UserDict
-from typing import Self
+from typing import Any, Self
 
 from .buffers.base_data_buffer import BaseDataBuffer
 from .interfaces import ThreadSafeDataCollector, ThreadSafeDataUser
 from .step_data import StepData
 
 
-class DataUsersDict(UserDict[str, ThreadSafeDataUser]):
+class DataUsersDict(UserDict[str, ThreadSafeDataUser[Any]]):
     """A class for aggregating `DataUsers` to share them from the inference
     thread to the training thread."""
 
 
-class DataCollectorsDict(UserDict[str, ThreadSafeDataCollector]):
+class DataCollectorsDict(UserDict[str, ThreadSafeDataCollector[Any]]):
     """A class for aggregating `DataCollectors` to invoke their `collect`
     methods within the agent class."""
 

--- a/ami/interactions/agents/base_agent.py
+++ b/ami/interactions/agents/base_agent.py
@@ -1,6 +1,6 @@
 """This file contains the abstract base agent class."""
 from abc import ABC, abstractmethod
-from typing import Generic
+from typing import Any, Generic
 
 import torch.nn as nn
 
@@ -50,7 +50,7 @@ class BaseAgent(ABC, Generic[ObsType, ActType]):
             raise KeyError(f"The specified model name '{name}' does not exist.")
         return self._inference_models[name]
 
-    def get_data_collector(self, name: str) -> ThreadSafeDataCollector:
+    def get_data_collector(self, name: str) -> ThreadSafeDataCollector[Any]:
         if name not in self.data_collectors:
             raise KeyError(f"The specified data collector name '{name}' does not exist.")
         return self.data_collectors[name]

--- a/ami/trainers/base_trainer.py
+++ b/ami/trainers/base_trainer.py
@@ -134,7 +134,7 @@ class BaseTrainer(ABC):
         model.unfreeze_model()
         return model
 
-    def get_data_user(self, name: str) -> ThreadSafeDataUser:
+    def get_data_user(self, name: str) -> ThreadSafeDataUser[Any]:
         """Retrieves the specified data user."""
         if name not in self._data_users_dict:
             raise KeyError(f"The specified data user name '{name}' does not exist.")

--- a/ami/trainers/image_vae_trainer.py
+++ b/ami/trainers/image_vae_trainer.py
@@ -8,6 +8,8 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 
 from ami.data.buffers.buffer_names import BufferNames
+from ami.data.buffers.random_data_buffer import RandomDataBuffer
+from ami.data.interfaces import ThreadSafeDataUser
 from ami.models.model_names import ModelNames
 from ami.models.model_wrapper import ModelWrapper
 from ami.models.vae import VAE, Decoder, Encoder
@@ -38,7 +40,7 @@ class ImageVAETrainer(BaseTrainer):
         self.kl_coef = kl_coef
 
     def on_data_users_dict_attached(self) -> None:
-        self.image_data_user = self.get_data_user(BufferNames.IMAGE)
+        self.image_data_user: ThreadSafeDataUser[RandomDataBuffer] = self.get_data_user(BufferNames.IMAGE)
 
     def on_model_wrappers_dict_attached(self) -> None:
         self.encoder: ModelWrapper[Encoder] = self.get_training_model(ModelNames.IMAGE_ENCODER)

--- a/tests/data/test_interfaces.py
+++ b/tests/data/test_interfaces.py
@@ -9,11 +9,11 @@ from .buffers.test_base_data_buffer import DataBufferImpl
 
 class TestDataCollectorAndUser:
     @pytest.fixture
-    def collector(self) -> ThreadSafeDataCollector:
+    def collector(self) -> ThreadSafeDataCollector[DataBufferImpl]:
         return ThreadSafeDataCollector(DataBufferImpl())
 
     @pytest.fixture
-    def user(self, collector: ThreadSafeDataCollector) -> ThreadSafeDataUser:
+    def user(self, collector: ThreadSafeDataCollector[DataBufferImpl]) -> ThreadSafeDataUser[DataBufferImpl]:
         return ThreadSafeDataUser(collector)
 
     @pytest.fixture
@@ -21,11 +21,11 @@ class TestDataCollectorAndUser:
         return StepData({DataKeys.OBSERVATION: torch.randn(10)})
 
     # --- Testing Collector ---
-    def test_collect(self, collector: ThreadSafeDataCollector, step_data: StepData) -> None:
+    def test_collect(self, collector: ThreadSafeDataCollector[DataBufferImpl], step_data: StepData) -> None:
 
         collector.collect(step_data)
 
-    def test_move_data(self, collector: ThreadSafeDataCollector) -> None:
+    def test_move_data(self, collector: ThreadSafeDataCollector[DataBufferImpl]) -> None:
 
         buffer = collector._buffer
         moved_buffer = collector.move_data()
@@ -34,7 +34,10 @@ class TestDataCollectorAndUser:
 
     # --- Testing User ---
     def test_get_dataset(
-        self, collector: ThreadSafeDataCollector, user: ThreadSafeDataUser, step_data: StepData
+        self,
+        collector: ThreadSafeDataCollector[DataBufferImpl],
+        user: ThreadSafeDataUser[DataBufferImpl],
+        step_data: StepData,
     ) -> None:
         collector.collect(step_data)
 
@@ -45,7 +48,12 @@ class TestDataCollectorAndUser:
         dataset = user.get_dataset()
         assert torch.equal(dataset[:][0], torch.stack([step_data[DataKeys.OBSERVATION]] * 2))
 
-    def test_clear(self, collector: ThreadSafeDataCollector, user: ThreadSafeDataUser, step_data: StepData) -> None:
+    def test_clear(
+        self,
+        collector: ThreadSafeDataCollector[DataBufferImpl],
+        user: ThreadSafeDataUser[DataBufferImpl],
+        step_data: StepData,
+    ) -> None:
         collector.collect(step_data)
 
         collector_buffer = collector._buffer


### PR DESCRIPTION
## 概要

#90 に関連して、Bufferに直接アクセスすることが求められるので(lenの取得のため)、前準備としてThreadSafeDataCollector/DataUserをDataBufferのGenerics化した。そしてそれに対応して型アノテーションを修正、追加した。


## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
