### PR TITLE
configファイル内でpythonの簡易呼び出しを可能に

### DIFF
--- a/ami/omegaconf_resolvers.py
+++ b/ami/omegaconf_resolvers.py
@@ -13,4 +13,5 @@ def register_custom_resolvers() -> None:
 
     if not _registered:
         OmegaConf.register_new_resolver("torch.device", torch.device)  # Usage: ${torch.device: cuda:0}
+        OmegaConf.register_new_resolver("python.eval", eval)  # Usage: ${python.eval: 'lambda x:x * 2'}
         _registered = True

--- a/tests/test_omegaconf_resolvers.py
+++ b/tests/test_omegaconf_resolvers.py
@@ -8,3 +8,4 @@ def test_resolovers():
     register_custom_resolvers()
 
     assert OmegaConf.create({"device": "${torch.device: cuda:0}"}).device == torch.device("cuda:0")
+    assert OmegaConf.create({"eval": "${python.eval: 1 + 2 * 3 / 4}"}).eval == 2.5


### PR DESCRIPTION
## 概要

設定ファイル内部で `python.eval`を呼び出し、簡易な計算や関数指定を可能にしました。configファイル内の値を用いてちょっとした計算等を可能にします。ただし、乱用すると設定ファイルの明示性が劣化します。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
