### PR TITLE
Markdownのテーブルの自動フォーマットを無効化

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
         args: ["--number"]
         additional_dependencies:
           - mdformat-gfm
-          - mdformat-tables
+          # - mdformat-tables
           - mdformat_frontmatter
           # - mdformat-toc
           # - mdformat-black


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
`mdformat-tables` は日本語に対応しておらず、テキストエディターで見た際にフォーマットが崩れるので、無効化します。

https://github.com/executablebooks/mdformat-tables/issues/16

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
`make format` の挙動。

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
特になし。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [X] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [X] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [X] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
