### PR TITLE
PrimitiveAMIのPolicyを引継

### DIFF
--- a/ami/models/components/discrete_policy_head.py
+++ b/ami/models/components/discrete_policy_head.py
@@ -1,0 +1,46 @@
+import torch
+from torch.distributions import Categorical, Distribution
+
+
+class MultiCategoricals(Distribution):
+    """Set of same action torch.Size categorical distributions."""
+
+    arg_constraints = {}
+
+    def __init__(self, distributions: list[Categorical]) -> None:
+        """Constructs Multi Categorical class. All `batch_shape` of child
+        categorical class must be same.
+
+        Args:
+            distributions: A list of Categorical distributions, where each distribution may have a different size of action choices.
+        """
+
+        assert len(distributions) > 0
+        first_dist = distributions[0]
+        assert all(first_dist.batch_shape == d.batch_shape for d in distributions), "All batch shapes must be same."
+
+        batch_shape = torch.Size((*first_dist.batch_shape, len(distributions)))
+        super().__init__(batch_shape=batch_shape, event_shape=torch.Size(), validate_args=False)
+
+        self.dists = distributions
+
+    def sample(self, sample_shape: torch.Size = torch.Size()) -> torch.Tensor:
+        """Sample from each distributions and stacks their outputs.
+
+        Shape:
+            return: (*sample_shape, num_dists)
+        """
+        return torch.stack([d.sample(sample_shape) for d in self.dists], dim=-1)
+
+    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
+        """Compute log probability of `value`
+
+        Shape:
+            value: (*, num_dists)
+            return: (*, num_dists)
+        """
+        return torch.stack([d.log_prob(v) for d, v in zip(self.dists, value.movedim(-1, 0))], dim=-1)
+
+    def entropy(self) -> torch.Tensor:
+        """Compute entropy for each distribution."""
+        return torch.stack([d.entropy() for d in self.dists], dim=-1)

--- a/ami/models/components/fully_connected_value_head.py
+++ b/ami/models/components/fully_connected_value_head.py
@@ -1,0 +1,11 @@
+import torch.nn as nn
+from torch import Tensor
+
+
+class FullyConnectedValueHead(nn.Module):
+    def __init__(self, dim_input: int) -> None:
+        super().__init__()
+        self.fc = nn.Linear(dim_input, 1)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.fc(x)

--- a/ami/models/policy_value_common_net.py
+++ b/ami/models/policy_value_common_net.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
+from torch import Tensor
 from torch.distributions import Distribution
 
 
@@ -13,3 +14,15 @@ class PolicyValueCommonNet(ABC, nn.Module):
     def forward(self, *args: Any, **kwds: Any) -> tuple[Distribution, torch.Tensor]:
         """Returns the action distribution and estimated value."""
         raise NotImplementedError
+
+
+class ModularPolicyValueCommonNet(PolicyValueCommonNet):
+    def __init__(self, base_model: nn.Module, policy_head: nn.Module, value_head: nn.Module) -> None:
+        super().__init__()
+        self.base_model = base_model
+        self.policy_head = policy_head
+        self.value_head = value_head
+
+    def forward(self, *args: Any, **kwds: Any) -> tuple[Distribution, Tensor]:
+        h = self.base_model(*args, **kwds)
+        return self.policy_head(h), self.value_head(h)

--- a/ami/models/policy_value_common_net.py
+++ b/ami/models/policy_value_common_net.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from torch.distributions import Distribution
 
 
-class PolicyValueCommonNet(nn.Module):
+class PolicyValueCommonNet(ABC, nn.Module):
     """Modules with shared models for policy and value functions."""
 
     @abstractmethod

--- a/ami/models/policy_value_common_net.py
+++ b/ami/models/policy_value_common_net.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.distributions import Distribution
+
+
+class PolicyValueCommonNet(nn.Module):
+    """Modules with shared models for policy and value functions."""
+
+    @abstractmethod
+    def forward(self, *args: Any, **kwds: Any) -> tuple[Distribution, torch.Tensor]:
+        """Returns the action distribution and estimated value."""
+        raise NotImplementedError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ ignore_missing_imports = true
 python_version = "3.11"
 implicit_reexport = true
 disallow_untyped_calls = false
+disable_error_code = "no-any-return"
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/tests/models/components/test_discrete_policy_head.py
+++ b/tests/models/components/test_discrete_policy_head.py
@@ -1,0 +1,31 @@
+import pytest
+import torch
+from torch.distributions import Categorical
+
+from ami.models.components.discrete_policy_head import MultiCategoricals
+
+
+class TestMultiCategoricals:
+    @pytest.fixture
+    def distributions(self) -> list[Categorical]:
+        choices_per_dist = [3, 2, 5]
+        batch_size = 8
+        return [Categorical(logits=torch.zeros(batch_size, c)) for c in choices_per_dist]
+
+    @pytest.fixture
+    def multi_categoricals(self, distributions) -> MultiCategoricals:
+        return MultiCategoricals(distributions)
+
+    def test_init(self, multi_categoricals: MultiCategoricals):
+        assert multi_categoricals.batch_shape == (8, 3)
+
+    def test_sample(self, multi_categoricals: MultiCategoricals):
+        assert multi_categoricals.sample().shape == (8, 3)
+        assert multi_categoricals.sample((1, 2)).shape == (1, 2, 8, 3)
+
+    def test_log_prob(self, multi_categoricals: MultiCategoricals):
+        sampled = multi_categoricals.sample()
+        assert multi_categoricals.log_prob(sampled).shape == sampled.shape
+
+    def test_entropy(self, multi_categoricals: MultiCategoricals):
+        assert multi_categoricals.entropy().shape == (8, 3)

--- a/tests/models/test_policy_value_common_net.py
+++ b/tests/models/test_policy_value_common_net.py
@@ -1,0 +1,25 @@
+import pytest
+import torch
+import torch.nn as nn
+from torch.distributions import Distribution
+
+from ami.models.components.discrete_policy_head import DiscretePolicyHead
+from ami.models.components.fully_connected_value_head import FullyConnectedValueHead
+from ami.models.policy_value_common_net import ModularPolicyValueCommonNet
+
+
+class TestModularPolicyValueCommonNet:
+    @pytest.fixture
+    def net(self) -> ModularPolicyValueCommonNet:
+        base_model = nn.Linear(128, 16)
+        policy = DiscretePolicyHead(16, [8])
+        value = FullyConnectedValueHead(16)
+
+        return ModularPolicyValueCommonNet(base_model, policy, value)
+
+    def test_forward(self, net: ModularPolicyValueCommonNet):
+
+        action_dist, value = net.forward(torch.randn(128))
+        assert isinstance(action_dist, Distribution)
+        assert action_dist.sample().shape == (1,)
+        assert value.shape == (1,)


### PR DESCRIPTION
## 概要

#101 モデルの構造は設定ファイルで指定します。FullyConnectedレイヤーは内部構造がわかりにくくなるので引き継ぎませんでした。
また、mypyで `Any`を返す場合を無視するようにしました。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
