### PR TITLE
OmegaConf内でtorch dtypeオブジェクトを生成可能に

### DIFF
--- a/ami/omegaconf_resolvers.py
+++ b/ami/omegaconf_resolvers.py
@@ -13,4 +13,24 @@ def register_custom_resolvers() -> None:
 
     if not _registered:
         OmegaConf.register_new_resolver("torch.device", torch.device)  # Usage: ${torch.device: cuda:0}
+        OmegaConf.register_new_resolver(
+            "torch.dtype", convert_dtype_str_to_torch_dtype
+        )  # Usage: ${torch.dtype: float32}
+
         _registered = True
+
+
+def convert_dtype_str_to_torch_dtype(dtype_str: str) -> torch.dtype:
+    """Convert the string of dtype such as "float32" to `torch.dtype` object
+    `torch.float32` .
+
+    All dtypes are listed in https://pytorch.org/docs/stable/tensor_attributes.html#torch-dtype
+    """
+    if hasattr(torch, dtype_str):
+        dtype = getattr(torch, dtype_str)
+    else:
+        raise ValueError(f"Dtype name {dtype_str} does not exists!")
+
+    if not isinstance(dtype, torch.dtype):
+        raise TypeError(f"Dtype name {dtype_str} is not dtype! Object: {dtype}")
+    return dtype

--- a/tests/test_omegaconf_resolvers.py
+++ b/tests/test_omegaconf_resolvers.py
@@ -8,3 +8,4 @@ def test_resolovers():
     register_custom_resolvers()
 
     assert OmegaConf.create({"device": "${torch.device: cuda:0}"}).device == torch.device("cuda:0")
+    assert OmegaConf.create({"dtype": "${torch.dtype: complex64}"}).dtype == torch.complex64


### PR DESCRIPTION
## 概要

OmegaConfのyamlコンフィグファイル内で `torch.dtype`オブジェクトを生成できるようにしました。
これは、pytorchがnumpyのようにdtypeを文字列型で指定することを許さないためです。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
