### PR TITLE
PPOTrajectoryBufferの実装

### DIFF
--- a/ami/data/buffers/causal_data_buffer.py
+++ b/ami/data/buffers/causal_data_buffer.py
@@ -20,7 +20,7 @@ class CausalDataBuffer(BaseDataBuffer):
         """
         self.__max_len = max_len
         self.__current_len = 0
-        self.__key_list = key_list
+        self._key_list = key_list
         self.__buffer_dict: dict[DataKeys, deque[torch.Tensor]] = dict()
         for key in key_list:
             self.__buffer_dict[key] = deque(maxlen=max_len)
@@ -39,7 +39,7 @@ class CausalDataBuffer(BaseDataBuffer):
         Args:
             step_data: A single step of data.
         """
-        for key in self.__key_list:
+        for key in self._key_list:
             self.__buffer_dict[key].append(torch.Tensor(step_data[key]))
         if self.__current_len < self.__max_len:
             self.__current_len += 1
@@ -54,7 +54,7 @@ class CausalDataBuffer(BaseDataBuffer):
         Args:
             new_data: A buffer to concatenate.
         """
-        for key in self.__key_list:
+        for key in self._key_list:
             self.buffer_dict[key] += new_data.buffer_dict[key]
         self.__current_len = min(len(self) + len(new_data), self.__max_len)
 
@@ -65,6 +65,6 @@ class CausalDataBuffer(BaseDataBuffer):
             TensorDataset: a TensorDataset created from current buffer.
         """
         tensor_list = []
-        for key in self.__key_list:
+        for key in self._key_list:
             tensor_list.append(torch.stack(list(self.__buffer_dict[key])))
         return TensorDataset(*tensor_list)

--- a/ami/data/buffers/ppo_trajectory_buffer.py
+++ b/ami/data/buffers/ppo_trajectory_buffer.py
@@ -50,9 +50,7 @@ class PPOTrajectoryBuffer(CausalDataBuffer):
         observations = tensor_dict[DataKeys.OBSERVATION][:-1]
         actions = tensor_dict[DataKeys.ACTION][:-1]
         logprobs = tensor_dict[DataKeys.ACTION_LOG_PROBABILITY][:-1]
-
-        raw_rewards = tensor_dict[DataKeys.REWARD]
-        rewards = raw_rewards[:-1]
+        rewards = tensor_dict[DataKeys.REWARD][:-1]
 
         raw_values = tensor_dict[DataKeys.VALUE]
         final_next_value = raw_values[-1]

--- a/ami/data/buffers/ppo_trajectory_buffer.py
+++ b/ami/data/buffers/ppo_trajectory_buffer.py
@@ -11,7 +11,7 @@ from .causal_data_buffer import CausalDataBuffer
 class PPOTrajectoryBuffer(CausalDataBuffer):
     """Buffering the trajectory data for ppo training.
 
-    Advantageの計算で次ステップの価値関数の推定値を用いる都合上、返されるデータセットの最大長は `max_len - 1`となる。
+    Advantageの計算で次ステップの価値関数の推定値を用いるため、返されるデータセットの長さは `len - 1`となる。
 
     Returning objects are;
         - observations

--- a/ami/data/buffers/ppo_trajectory_buffer.py
+++ b/ami/data/buffers/ppo_trajectory_buffer.py
@@ -1,0 +1,95 @@
+from collections import OrderedDict
+
+import torch
+from torch import Tensor
+from torch.utils.data import TensorDataset
+
+from ..step_data import DataKeys
+from .causal_data_buffer import CausalDataBuffer
+
+
+class PPOTrajectoryBuffer(CausalDataBuffer):
+    """Buffering the trajectory data for ppo training.
+
+    Advantageの計算で次ステップの価値関数の推定値を用いる都合上、返されるデータセットの最大長は `max_len - 1`となる。
+
+    Returning objects are;
+        - observations
+        - actions
+        - action log probabilities
+        - advantages
+        - returns
+        - values
+    """
+
+    def init(self, max_len: int, gamma: float = 0.99, gae_lambda: float = 0.95) -> None:  # type: ignore
+        """
+        Args:
+            max_size: The max size of internal buffer.
+            gamma: Discount factor.
+            gae_lambda: The lambda of generalized advantage estimation.
+        """
+        super().init(
+            max_len,
+            key_list=[
+                DataKeys.OBSERVATION,
+                DataKeys.ACTION,
+                DataKeys.ACTION_LOG_PROBABILITY,
+                DataKeys.REWARD,
+                DataKeys.VALUE,
+            ],
+        )
+        self.gamma = gamma
+        self.gae_lambda = gae_lambda
+
+    def make_dataset(self) -> TensorDataset:
+        tensor_dict = OrderedDict()
+        for key in self._key_list:
+            tensor_dict[key] = torch.stack(list(self.buffer_dict[key]))
+
+        observations = tensor_dict[DataKeys.OBSERVATION][:-1]
+        actions = tensor_dict[DataKeys.ACTION][:-1]
+        logprobs = tensor_dict[DataKeys.ACTION_LOG_PROBABILITY][:-1]
+
+        raw_rewards = tensor_dict[DataKeys.REWARD]
+        rewards = raw_rewards[:-1]
+
+        raw_values = tensor_dict[DataKeys.VALUE]
+        final_next_value = raw_values[-1]
+        values = raw_values[:-1]
+
+        advantages = compute_advantage(rewards, values, final_next_value, self.gamma, self.gae_lambda)
+        returns = advantages + values
+
+        return TensorDataset(observations, actions, logprobs, advantages, returns, values)
+
+
+def compute_advantage(
+    rewards: Tensor, values: Tensor, final_next_value: Tensor, gamma: float, gae_lambda: float
+) -> Tensor:
+    """Compute advantages from values.
+
+    Args:
+        rewards: shape (step length, )
+        values: shape (step length, )
+        final_next_value: shape (1,)
+        gamma: Discount factor.
+        gae_lambda: The lambda of generalized advantage estimation.
+
+    Returns:
+        advantages: shape
+    """
+    advantages = torch.empty_like(values)
+
+    lastgaelam = torch.Tensor([0.0])
+
+    for t in reversed(range(values.size(0))):
+        if t == values.size(0) - 1:
+            nextvalues = final_next_value
+        else:
+            nextvalues = values[t + 1]
+
+        delta = rewards[t] + gamma * nextvalues - values[t]
+        advantages[t] = lastgaelam = delta + gamma * gae_lambda * lastgaelam
+
+    return advantages

--- a/tests/data/buffers/test_ppo_trajectory_buffer.py
+++ b/tests/data/buffers/test_ppo_trajectory_buffer.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+from ami.data.buffers.ppo_trajectory_buffer import PPOTrajectoryBuffer
+from ami.data.step_data import DataKeys, StepData
+
+
+class TestPPOTrajectoryBuffer:
+    @pytest.mark.parametrize(
+        """
+        max_size,
+        gamma,
+        gae_lambda,
+        observation_shape,
+        action_shape,
+        num_collect,
+        """,
+        [(128, 0.99, 0.99, (64, 64), (64, 64), 256), (64, 0.98, 0.999, (3, 84, 84), (5,), 32)],
+    )
+    def test_make_dataset(self, max_size, gamma, gae_lambda, observation_shape, action_shape, num_collect):
+        buffer = PPOTrajectoryBuffer(max_size, gamma, gae_lambda)
+
+        for _ in range(num_collect):
+            step_data = StepData()
+            step_data[DataKeys.OBSERVATION] = torch.randn(*observation_shape)
+            step_data[DataKeys.ACTION] = torch.randn(*action_shape)
+            step_data[DataKeys.ACTION_LOG_PROBABILITY] = torch.randn(*action_shape)
+            step_data[DataKeys.REWARD] = torch.randn(1)
+            step_data[DataKeys.VALUE] = torch.randn(1)
+
+            buffer.add(step_data)
+
+        dataset = buffer.make_dataset()
+
+        length = min(max_size, num_collect) - 1
+        observations, actions, logprobs, advantages, returns, values = dataset[0:length]
+        assert observations.size() == (length, *observation_shape)
+        assert actions.size() == (length, *action_shape)
+        assert logprobs.size() == (length, *action_shape)
+        assert advantages.size() == (length, 1)
+        assert returns.size() == (length, 1)
+        assert values.size() == (length, 1)


### PR DESCRIPTION
## 概要

#108 CausalDataBufferを継承する形で実装しました。
サブクラスでも`_key_list`を参照できるようにしました。

`init`の引数が異なって mypyがエラーを吐くので一旦 ignoreしました。
リファクタリングする予定です。https://gist.github.com/Geson-anko/98099bdfc5a2c203e27138b5137fa34b

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
