### PR TITLE
PolicyValueCommonNetをリファクタリング

### DIFF
--- a/ami/models/policy_value_common_net.py
+++ b/ami/models/policy_value_common_net.py
@@ -1,22 +1,13 @@
-from abc import ABC, abstractmethod
 from typing import Any
 
-import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.distributions import Distribution
 
 
-class PolicyValueCommonNet(ABC, nn.Module):
+class PolicyValueCommonNet(nn.Module):
     """Modules with shared models for policy and value functions."""
 
-    @abstractmethod
-    def forward(self, *args: Any, **kwds: Any) -> tuple[Distribution, torch.Tensor]:
-        """Returns the action distribution and estimated value."""
-        raise NotImplementedError
-
-
-class ModularPolicyValueCommonNet(PolicyValueCommonNet):
     def __init__(self, base_model: nn.Module, policy_head: nn.Module, value_head: nn.Module) -> None:
         super().__init__()
         self.base_model = base_model
@@ -24,5 +15,6 @@ class ModularPolicyValueCommonNet(PolicyValueCommonNet):
         self.value_head = value_head
 
     def forward(self, *args: Any, **kwds: Any) -> tuple[Distribution, Tensor]:
+        """Returns the action distribution and estimated value."""
         h = self.base_model(*args, **kwds)
         return self.policy_head(h), self.value_head(h)

--- a/tests/models/test_policy_value_common_net.py
+++ b/tests/models/test_policy_value_common_net.py
@@ -5,19 +5,19 @@ from torch.distributions import Distribution
 
 from ami.models.components.discrete_policy_head import DiscretePolicyHead
 from ami.models.components.fully_connected_value_head import FullyConnectedValueHead
-from ami.models.policy_value_common_net import ModularPolicyValueCommonNet
+from ami.models.policy_value_common_net import PolicyValueCommonNet
 
 
-class TestModularPolicyValueCommonNet:
+class TestPolicyValueCommonNet:
     @pytest.fixture
-    def net(self) -> ModularPolicyValueCommonNet:
+    def net(self) -> PolicyValueCommonNet:
         base_model = nn.Linear(128, 16)
         policy = DiscretePolicyHead(16, [8])
         value = FullyConnectedValueHead(16)
 
-        return ModularPolicyValueCommonNet(base_model, policy, value)
+        return PolicyValueCommonNet(base_model, policy, value)
 
-    def test_forward(self, net: ModularPolicyValueCommonNet):
+    def test_forward(self, net: PolicyValueCommonNet):
 
         action_dist, value = net.forward(torch.randn(128))
         assert isinstance(action_dist, Distribution)

--- a/tests/trainers/test_ppo_policy_trainer.py
+++ b/tests/trainers/test_ppo_policy_trainer.py
@@ -14,7 +14,7 @@ from ami.models.components.discrete_policy_head import DiscretePolicyHead
 from ami.models.components.fully_connected_value_head import FullyConnectedValueHead
 from ami.models.model_names import ModelNames
 from ami.models.model_wrapper import ModelWrapper
-from ami.models.policy_value_common_net import ModularPolicyValueCommonNet
+from ami.models.policy_value_common_net import PolicyValueCommonNet
 from ami.models.utils import ModelWrappersDict
 from ami.trainers.ppo_policy_trainer import PPOPolicyTrainer
 
@@ -36,7 +36,7 @@ class TestPPOPolicyTrainer:
         policy = DiscretePolicyHead(16, [8])
         value = FullyConnectedValueHead(16)
 
-        return ModularPolicyValueCommonNet(base_model, policy, value)
+        return PolicyValueCommonNet(base_model, policy, value)
 
     @pytest.fixture
     def policy_value_wrappers_dict(


### PR DESCRIPTION
## 概要

抽象 PolicyValueCommonNetを定義していたが、基本的に `ModularPolicyValueCommonNet`しか使わないため、抽象クラスを削除して`ModularPolicyValueCommonNet`から`Modular`を消した。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
