### PR TITLE
Feature/#96/hydra instantiators

### DIFF
--- a/ami/hydra_instantiators.py
+++ b/ami/hydra_instantiators.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+import hydra
+from omegaconf import DictConfig, ListConfig
+
+from .data.buffers.buffer_names import BufferNames
+from .data.utils import BaseDataBuffer, DataCollectorsDict, ThreadSafeDataCollector
+from .logger import get_main_thread_logger
+from .models.model_names import ModelNames
+from .models.utils import ModelWrappersDict
+from .trainers.utils import TrainersList
+
+logger = get_main_thread_logger(__name__)
+
+
+def instantiate_data_collectors(data_collectors_cfg: DictConfig) -> DataCollectorsDict:
+    d = DataCollectorsDict()
+    for name, cfg in data_collectors_cfg.items():
+        logger.info(f"Instantiating DataCollector <{cfg._target_}>")
+        buffer_or_collector: BaseDataBuffer | ThreadSafeDataCollector[Any] = hydra.utils.instantiate(cfg)
+
+        match buffer_or_collector:
+            case BaseDataBuffer():
+                collector = ThreadSafeDataCollector(buffer_or_collector)
+            case ThreadSafeDataCollector():
+                collector = buffer_or_collector
+            case _:
+                raise TypeError(f"Instatiated {cfg._target_} must be a DataBuffer or DataCollector!")
+
+        d[BufferNames(str(name))] = collector
+    return d

--- a/ami/hydra_instantiators.py
+++ b/ami/hydra_instantiators.py
@@ -8,7 +8,7 @@ from .data.utils import BaseDataBuffer, DataCollectorsDict, ThreadSafeDataCollec
 from .logger import get_main_thread_logger
 from .models.model_names import ModelNames
 from .models.utils import ModelWrapper, ModelWrappersDict
-from .trainers.utils import TrainersList
+from .trainers.utils import BaseTrainer, TrainersList
 
 logger = get_main_thread_logger(__name__)
 
@@ -42,3 +42,13 @@ def instantiate_models(models_cfg: DictConfig) -> ModelWrappersDict:
 
         d[ModelNames(str(name))] = model_wrapper
     return d
+
+
+def instantiate_trainers(trainers_cfg: ListConfig) -> TrainersList:
+    tl = TrainersList()
+    for i, cfg in enumerate(trainers_cfg):
+        logger.info(f"Instatiating Trainer[{i}]: <{cfg._target_}>")
+        trainer: BaseTrainer = hydra.utils.instantiate(cfg)
+        tl.append(trainer)
+
+    return tl

--- a/ami/hydra_instantiators.py
+++ b/ami/hydra_instantiators.py
@@ -16,7 +16,7 @@ logger = get_main_thread_logger(__name__)
 def instantiate_data_collectors(data_collectors_cfg: DictConfig) -> DataCollectorsDict:
     d = DataCollectorsDict()
     for name, cfg in data_collectors_cfg.items():
-        logger.info(f"Instantiating DataCollector <{cfg._target_}>")
+        logger.info(f"Instantiating <{cfg._target_}>")
         buffer_or_collector: BaseDataBuffer | ThreadSafeDataCollector[Any] = hydra.utils.instantiate(cfg)
 
         match buffer_or_collector:
@@ -27,6 +27,8 @@ def instantiate_data_collectors(data_collectors_cfg: DictConfig) -> DataCollecto
             case _:
                 raise TypeError(f"Instatiated {cfg._target_} must be a DataBuffer or DataCollector!")
 
+        logger.info(f"Instatiated <{collector.__class__.__name__}[{collector._buffer.__class__.__name__}]>")
+
         d[BufferNames(str(name))] = collector
     return d
 
@@ -34,8 +36,8 @@ def instantiate_data_collectors(data_collectors_cfg: DictConfig) -> DataCollecto
 def instantiate_models(models_cfg: DictConfig) -> ModelWrappersDict:
     d = ModelWrappersDict()
     for name, cfg in models_cfg.items():
+        logger.info(f"Instantiating <{cfg._target_}[{cfg.model._target_}]>")
         model_wrapper: ModelWrapper[Any] = hydra.utils.instantiate(cfg)
-        logger.info(f"Instantiated {cfg._target_}[{cfg.model._target_}]")
 
         if not isinstance(model_wrapper, ModelWrapper):
             raise TypeError(f"Instantiated {cfg._target_} must be a ModelWrapper! Type: {type(model_wrapper)}")
@@ -47,7 +49,7 @@ def instantiate_models(models_cfg: DictConfig) -> ModelWrappersDict:
 def instantiate_trainers(trainers_cfg: ListConfig) -> TrainersList:
     tl = TrainersList()
     for i, cfg in enumerate(trainers_cfg):
-        logger.info(f"Instatiating Trainer[{i}]: <{cfg._target_}>")
+        logger.info(f"Instatiating Trainer {i}: <{cfg._target_}>")
         trainer: BaseTrainer = hydra.utils.instantiate(cfg)
         tl.append(trainer)
 

--- a/ami/hydra_instantiators.py
+++ b/ami/hydra_instantiators.py
@@ -7,7 +7,7 @@ from .data.buffers.buffer_names import BufferNames
 from .data.utils import BaseDataBuffer, DataCollectorsDict, ThreadSafeDataCollector
 from .logger import get_main_thread_logger
 from .models.model_names import ModelNames
-from .models.utils import ModelWrappersDict
+from .models.utils import ModelWrapper, ModelWrappersDict
 from .trainers.utils import TrainersList
 
 logger = get_main_thread_logger(__name__)
@@ -28,4 +28,17 @@ def instantiate_data_collectors(data_collectors_cfg: DictConfig) -> DataCollecto
                 raise TypeError(f"Instatiated {cfg._target_} must be a DataBuffer or DataCollector!")
 
         d[BufferNames(str(name))] = collector
+    return d
+
+
+def instantiate_models(models_cfg: DictConfig) -> ModelWrappersDict:
+    d = ModelWrappersDict()
+    for name, cfg in models_cfg.items():
+        model_wrapper: ModelWrapper[Any] = hydra.utils.instantiate(cfg)
+        logger.info(f"Instantiated {cfg._target_}[{cfg.model._target_}]")
+
+        if not isinstance(model_wrapper, ModelWrapper):
+            raise TypeError(f"Instantiated {cfg._target_} must be a ModelWrapper! Type: {type(model_wrapper)}")
+
+        d[ModelNames(str(name))] = model_wrapper
     return d

--- a/configs/data_collectors/image.yaml
+++ b/configs/data_collectors/image.yaml
@@ -1,5 +1,3 @@
-_target_: ami.data.utils.DataCollectorsDict.from_data_buffers
-
 image:
   _target_: ami.data.buffers.random_data_buffer.RandomDataBuffer.reconstructable_init
   max_len: 2048 # From Primitive AMI.

--- a/configs/models/image_vae.yaml
+++ b/configs/models/image_vae.yaml
@@ -1,5 +1,3 @@
-_target_: ami.models.utils.ModelWrappersDict
-
 image_encoder:
   _target_: ami.models.vae.EncoderWrapper
   default_device: ${devices.0}

--- a/configs/trainers/image_vae.yaml
+++ b/configs/trainers/image_vae.yaml
@@ -1,13 +1,11 @@
-_target_: ami.trainers.utils.TrainersList
-_args_:
-  - _target_: ami.trainers.image_vae_trainer.ImageVAETrainer
-    partial_dataloader:
-      _target_: torch.utils.data.DataLoader
-      _partial_: true
-      batch_size: 16
-      shuffle: true
-    partial_optimizer:
-      _target_: torch.optim.Adam
-      _partial_: true
-      lr: 0.001
-    device: ${devices.0}
+- _target_: ami.trainers.image_vae_trainer.ImageVAETrainer
+  partial_dataloader:
+    _target_: torch.utils.data.DataLoader
+    _partial_: true
+    batch_size: 16
+    shuffle: true
+  partial_optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 0.001
+  device: ${devices.0}

--- a/scripts/launch.py
+++ b/scripts/launch.py
@@ -15,6 +15,7 @@ from ami.threads import (
     attach_shared_objects_pool_to_threads,
 )
 from ami.trainers.utils import TrainersList
+from ami.hydra_instantiators import instantiate_data_collectors, instantiate_models, instantiate_trainers
 
 # Add the project root path to environment vartiable `PROJECT_ROOT`
 # to refer in the config file by `${oc.env:PROJECT_ROOT}`.
@@ -33,15 +34,15 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Instantiating Interaction <{cfg.interaction._target_}>")
     interaction: Interaction = hydra.utils.instantiate(cfg.interaction)
 
-    logger.info(f"Instantiating DataCollectors <{cfg.data_collectors._target_}>")
-    data_collectors: DataCollectorsDict = hydra.utils.instantiate(cfg.data_collectors)
+    logger.info(f"Instantiating DataCollectors...")
+    data_collectors: DataCollectorsDict = instantiate_data_collectors(cfg.data_collectors)
 
-    logger.info(f"Instantiating Models <{cfg.models._target_}>")
-    models: ModelWrappersDict = hydra.utils.instantiate(cfg.models)
+    logger.info(f"Instantiating Models...")
+    models: ModelWrappersDict = instantiate_models(cfg.models)
     models.send_to_default_device()
 
-    logger.info(f"Instantiating Trainers <{cfg.trainers._target_}>")
-    trainers: TrainersList = hydra.utils.instantiate(cfg.trainers)
+    logger.info(f"Instantiating Trainers...")
+    trainers: TrainersList = instantiate_trainers(cfg.trainers)
 
     logger.info("Instantiating Thread Classes...")
     threads_cfg = cfg.threads

--- a/scripts/launch.py
+++ b/scripts/launch.py
@@ -4,6 +4,11 @@ import rootutils
 from omegaconf import DictConfig
 
 from ami.data.utils import DataCollectorsDict
+from ami.hydra_instantiators import (
+    instantiate_data_collectors,
+    instantiate_models,
+    instantiate_trainers,
+)
 from ami.interactions.interaction import Interaction
 from ami.logger import get_main_thread_logger
 from ami.models.utils import ModelWrappersDict
@@ -15,7 +20,6 @@ from ami.threads import (
     attach_shared_objects_pool_to_threads,
 )
 from ami.trainers.utils import TrainersList
-from ami.hydra_instantiators import instantiate_data_collectors, instantiate_models, instantiate_trainers
 
 # Add the project root path to environment vartiable `PROJECT_ROOT`
 # to refer in the config file by `${oc.env:PROJECT_ROOT}`.
@@ -34,14 +38,14 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Instantiating Interaction <{cfg.interaction._target_}>")
     interaction: Interaction = hydra.utils.instantiate(cfg.interaction)
 
-    logger.info(f"Instantiating DataCollectors...")
+    logger.info("Instantiating DataCollectors...")
     data_collectors: DataCollectorsDict = instantiate_data_collectors(cfg.data_collectors)
 
-    logger.info(f"Instantiating Models...")
+    logger.info("Instantiating Models...")
     models: ModelWrappersDict = instantiate_models(cfg.models)
     models.send_to_default_device()
 
-    logger.info(f"Instantiating Trainers...")
+    logger.info("Instantiating Trainers...")
     trainers: TrainersList = instantiate_trainers(cfg.trainers)
 
     logger.info("Instantiating Thread Classes...")

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3,6 +3,7 @@ import hydra
 import pytest
 from hydra.utils import instantiate
 
+from ami.hydra_instantiators import instantiate_data_collectors
 from ami.omegaconf_resolvers import register_custom_resolvers
 from tests.helpers import PROJECT_ROOT
 
@@ -23,7 +24,7 @@ def test_instantiate(overrides: list[str]):
         cfg = hydra.compose(LAUNCH_CONFIG, overrides=overrides)
 
         interaction = instantiate(cfg.interaction)
-        data_collectors = instantiate(cfg.data_collectors)
+        data_collectors = instantiate_data_collectors(cfg.data_collectors)
         models = instantiate(cfg.models)
         trainers = instantiate(cfg.trainers)
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3,7 +3,7 @@ import hydra
 import pytest
 from hydra.utils import instantiate
 
-from ami.hydra_instantiators import instantiate_data_collectors
+from ami.hydra_instantiators import instantiate_data_collectors, instantiate_models
 from ami.omegaconf_resolvers import register_custom_resolvers
 from tests.helpers import PROJECT_ROOT
 
@@ -25,7 +25,7 @@ def test_instantiate(overrides: list[str]):
 
         interaction = instantiate(cfg.interaction)
         data_collectors = instantiate_data_collectors(cfg.data_collectors)
-        models = instantiate(cfg.models)
+        models = instantiate_models(cfg.models)
         trainers = instantiate(cfg.trainers)
 
         threads = cfg.threads

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3,7 +3,11 @@ import hydra
 import pytest
 from hydra.utils import instantiate
 
-from ami.hydra_instantiators import instantiate_data_collectors, instantiate_models
+from ami.hydra_instantiators import (
+    instantiate_data_collectors,
+    instantiate_models,
+    instantiate_trainers,
+)
 from ami.omegaconf_resolvers import register_custom_resolvers
 from tests.helpers import PROJECT_ROOT
 
@@ -26,7 +30,7 @@ def test_instantiate(overrides: list[str]):
         interaction = instantiate(cfg.interaction)
         data_collectors = instantiate_data_collectors(cfg.data_collectors)
         models = instantiate_models(cfg.models)
-        trainers = instantiate(cfg.trainers)
+        trainers = instantiate_trainers(cfg.trainers)
 
         threads = cfg.threads
         instantiate(threads.main_thread)


### PR DESCRIPTION
## 概要

#96 タスクissueは書きかけですが、hydraによる`instantiate`時に DataCollector, Model, Trainerのインスタンス対象が何かわかりやすいように修正しました。そしてconfigファイルから `DataCollectorsDict`, `ModelWrappersDict`, `TrainersList`の記述を削除しました。これらの集約クラスは基本的にconfigurationの対象にならないためです。

## output ログ
```
[2024-03-29 14:58:34,757][main.__main__][INFO] - Launch AMI.
[2024-03-29 14:58:34,757][main.__main__][INFO] - Instantiating Interaction <ami.interactions.fixed_interval_interaction.FixedIntervalInteraction>
[2024-03-29 14:58:34,759][main.__main__][INFO] - Instantiating DataCollectors...
[2024-03-29 14:58:34,759][main.ami.hydra_instantiators][INFO] - Instantiating <ami.data.buffers.random_data_buffer.RandomDataBuffer.reconstructable_init>
[2024-03-29 14:58:34,759][main.ami.hydra_instantiators][INFO] - Instatiated <ThreadSafeDataCollector[RandomDataBuffer]>
[2024-03-29 14:58:34,759][main.__main__][INFO] - Instantiating Models...
[2024-03-29 14:58:34,760][main.ami.hydra_instantiators][INFO] - Instantiating <ami.models.vae.EncoderWrapper[ami.models.vae.Conv2dEncoder]>
[2024-03-29 14:58:35,047][main.ami.hydra_instantiators][INFO] - Instantiating <ami.models.model_wrapper.ModelWrapper[ami.models.vae.Conv2dDecoder]>
[2024-03-29 14:58:35,067][main.__main__][INFO] - Instantiating Trainers...
[2024-03-29 14:58:35,068][main.ami.hydra_instantiators][INFO] - Instatiating Trainer 0: <ami.trainers.image_vae_trainer.ImageVAETrainer>
```

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
