### PR TITLE
テスト時の GPU デバイスから mpsを削除

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,8 +22,9 @@ def get_gpu_device() -> torch.device | None:
     """Return the available gpu device."""
     if torch.cuda.is_available():
         return torch.device("cuda:0")
-    elif torch.backends.mps.is_available():
-        return torch.device("mps:0")
+    # MPS support has been dropped because `Tensor.angle` is not implemented for metal devices.
+    # elif torch.backends.mps.is_available():
+    #     return torch.device("mps:0")
     else:
         return None
 


### PR DESCRIPTION
## 概要

`Tensor.angle`が MPS上で実装されておらず、エラーになるため、メタルデバイスのサポートを取りやめた。

## エラーメッセージ

> \>       phazor = torch.exp(-phazor.real * phazor.real - phazor.imag * phazor.imag) * torch.exp(1.0j * phazor.angle())
> E       NotImplementedError: The operator 'aten::angle' is not currently implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.


## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
