### PR TITLE
`interaction`モジュールに`save_state`を実装

### DIFF
--- a/ami/interactions/agents/base_agent.py
+++ b/ami/interactions/agents/base_agent.py
@@ -1,5 +1,6 @@
 """This file contains the abstract base agent class."""
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Generic
 
 import torch.nn as nn
@@ -88,3 +89,7 @@ class BaseAgent(ABC, Generic[ObsType, ActType]):
             action: Final action to be taken in the interaction. Returning no action is also an option.
         """
         return None
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal state to `path`."""
+        pass

--- a/ami/interactions/agents/curiosity_image_ppo_agent.py
+++ b/ami/interactions/agents/curiosity_image_ppo_agent.py
@@ -1,6 +1,10 @@
+from pathlib import Path
+
+import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.distributions import Distribution
+from typing_extensions import override
 
 from ...data.buffers.buffer_names import BufferNames
 from ...data.step_data import DataKeys, StepData
@@ -85,3 +89,8 @@ class CuriosityImagePPOAgent(BaseAgent[Tensor, Tensor]):
 
     def step(self, observation: Tensor) -> Tensor:
         return self._common_step(observation, initial_step=False)
+
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.forward_dynamics_hidden_state, path / "forward_dynamics_hidden_state.pt")

--- a/ami/interactions/environments/actuators/base_actuator.py
+++ b/ami/interactions/environments/actuators/base_actuator.py
@@ -1,6 +1,7 @@
 """This file contains the abstract base actuator and actuator wrappers
 class."""
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Generic
 
 from ..._types import ActType, WrapperActType
@@ -26,6 +27,9 @@ class BaseActuator(ABC, Generic[ActType]):
     def teardown(self) -> None:
         """Called at the end of interaction with the agent."""
         pass
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal state to the `path`."""
 
 
 class BaseActuatorWrapper(BaseActuator[WrapperActType], Generic[WrapperActType, ActType]):

--- a/ami/interactions/environments/actuators/base_actuator.py
+++ b/ami/interactions/environments/actuators/base_actuator.py
@@ -30,6 +30,7 @@ class BaseActuator(ABC, Generic[ActType]):
 
     def save_state(self, path: Path) -> None:
         """Saves the internal state to the `path`."""
+        pass
 
 
 class BaseActuatorWrapper(BaseActuator[WrapperActType], Generic[WrapperActType, ActType]):

--- a/ami/interactions/environments/base_environment.py
+++ b/ami/interactions/environments/base_environment.py
@@ -36,3 +36,4 @@ class BaseEnvironment(ABC, Generic[ObsType, ActType]):
 
     def save_state(self, path: Path) -> None:
         """Saves the internal state to the `path`."""
+        pass

--- a/ami/interactions/environments/base_environment.py
+++ b/ami/interactions/environments/base_environment.py
@@ -1,5 +1,6 @@
 """This file contains the abstract base environment class."""
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Generic
 
 from .._types import ActType, ObsType
@@ -32,3 +33,6 @@ class BaseEnvironment(ABC, Generic[ObsType, ActType]):
     def teardown(self) -> None:
         """Called at the end of interaction with the agent."""
         pass
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal state to the `path`."""

--- a/ami/interactions/environments/sensor_actuator_env.py
+++ b/ami/interactions/environments/sensor_actuator_env.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any, Generic
 
 from .._types import ActType, ObsType
@@ -26,3 +27,9 @@ class SensorActuatorEnv(BaseEnvironment[ObsType, ActType], Generic[ObsType, ActT
     def teardown(self) -> None:
         self.sensor.teardown()
         self.actuator.teardown()
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal state to the `path`."""
+        path.mkdir()
+        self.sensor.save_state(path / "sensor")
+        self.actuator.save_state(path / "actuator")

--- a/ami/interactions/environments/sensor_actuator_env.py
+++ b/ami/interactions/environments/sensor_actuator_env.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Any, Generic
 
+from typing_extensions import override
+
 from .._types import ActType, ObsType
 from .actuators.base_actuator import BaseActuator
 from .base_environment import BaseEnvironment
@@ -28,6 +30,7 @@ class SensorActuatorEnv(BaseEnvironment[ObsType, ActType], Generic[ObsType, ActT
         self.sensor.teardown()
         self.actuator.teardown()
 
+    @override
     def save_state(self, path: Path) -> None:
         """Saves the internal state to the `path`."""
         path.mkdir()

--- a/ami/interactions/environments/sensors/base_sensor.py
+++ b/ami/interactions/environments/sensors/base_sensor.py
@@ -1,5 +1,6 @@
 """This file contains the abstract base sensor and sensor wrapper class."""
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Generic
 
 from ..._types import ObsType, WrapperObsType
@@ -24,6 +25,10 @@ class BaseSensor(ABC, Generic[ObsType]):
 
     def teardown(self) -> None:
         """Called at the end of interaction with the agent."""
+        pass
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal state to the `path`."""
         pass
 
 

--- a/ami/interactions/interaction.py
+++ b/ami/interactions/interaction.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ._types import ActType, ObsType
 from .agents.base_agent import BaseAgent
 from .environments.base_environment import BaseEnvironment
@@ -35,3 +37,9 @@ class Interaction:
         if final_action is not None:
             self.environment.affect(final_action)
         self.environment.teardown()
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal state to `path`."""
+        path.mkdir()
+        self.agent.save_state(path / "agent")
+        self.environment.save_state(path / "environment")

--- a/tests/interactions/agents/test_curiosity_image_ppo_agent.py
+++ b/tests/interactions/agents/test_curiosity_image_ppo_agent.py
@@ -97,3 +97,8 @@ class TestCuriosityImagePPOAgent:
         for _ in range(10):
             action = agent.step(observation)
             assert action.shape == (len(ACTION_CHOICES_PER_CATEGORY),)
+
+    def test_save_state(self, agent: CuriosityImagePPOAgent, tmp_path):
+        agent_path = tmp_path / "agent"
+        agent.save_state(agent_path)
+        assert agent_path.exists()

--- a/tests/interactions/agents/test_curiosity_image_ppo_agent.py
+++ b/tests/interactions/agents/test_curiosity_image_ppo_agent.py
@@ -101,4 +101,4 @@ class TestCuriosityImagePPOAgent:
     def test_save_state(self, agent: CuriosityImagePPOAgent, tmp_path):
         agent_path = tmp_path / "agent"
         agent.save_state(agent_path)
-        assert agent_path.exists()
+        assert (agent_path / "forward_dynamics_hidden_state.pt").exists()

--- a/tests/interactions/environments/test_sensor_actuator_env.py
+++ b/tests/interactions/environments/test_sensor_actuator_env.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -32,3 +34,15 @@ class TestSensorActuatorEnv:
         environment.teardown()
         environment.sensor.teardown.assert_called_once()
         environment.actuator.teardown.assert_called_once()
+
+    def test_save_state(self, environment: SensorActuatorEnv, tmp_path: Path) -> None:
+        env_path = tmp_path / "environment"
+        environment.save_state(env_path)
+        sensor_path = env_path / "sensor"
+        actuator_path = env_path / "actuator"
+        assert env_path.exists()
+
+        environment.sensor.save_state.assert_called_once_with(sensor_path)
+        environment.actuator.save_state.assert_called_once_with(actuator_path)
+        assert sensor_path.exists() is False
+        assert actuator_path.exists() is False

--- a/tests/interactions/environments/test_sensor_actuator_env.py
+++ b/tests/interactions/environments/test_sensor_actuator_env.py
@@ -44,5 +44,5 @@ class TestSensorActuatorEnv:
 
         environment.sensor.save_state.assert_called_once_with(sensor_path)
         environment.actuator.save_state.assert_called_once_with(actuator_path)
-        assert sensor_path.exists() is False
-        assert actuator_path.exists() is False
+        assert not sensor_path.exists()
+        assert not actuator_path.exists()

--- a/tests/interactions/test_interaction.py
+++ b/tests/interactions/test_interaction.py
@@ -41,8 +41,8 @@ class TestInteraction:
         environment_path = interaction_path / "environment"
 
         interaction.save_state(interaction_path)
-        assert interaction_path.exists() is True
-        assert agent_path.exists() is False
-        assert environment_path.exists() is False
+        assert interaction_path.exists()
+        assert not agent_path.exists()
+        assert not environment_path.exists()
         mock_env.save_state.assert_called_once_with(environment_path)
         mock_agent.save_state.assert_called_once_with(agent_path)

--- a/tests/interactions/test_interaction.py
+++ b/tests/interactions/test_interaction.py
@@ -33,3 +33,16 @@ class TestInteraction:
         mock_agent.teardown.assert_called_once_with("observation")
         mock_env.affect.assert_called_once_with("teardown_action")
         mock_env.teardown.assert_called_once()
+
+    def test_save_state(self, mock_env: Mock, mock_agent: Mock, tmp_path) -> None:
+        interaction = Interaction(mock_env, mock_agent)
+        interaction_path = tmp_path / "interaction"
+        agent_path = interaction_path / "agent"
+        environment_path = interaction_path / "environment"
+
+        interaction.save_state(interaction_path)
+        assert interaction_path.exists() is True
+        assert agent_path.exists() is False
+        assert environment_path.exists() is False
+        mock_env.save_state.assert_called_once_with(environment_path)
+        mock_agent.save_state.assert_called_once_with(agent_path)


### PR DESCRIPTION
## 概要

#94 はじめにagent, environment, interactionに`save_state`を実装しました。
注意として、与えられる`path`は必ずしもディレクトリになるわけではなく、例えば一つのpickleファイルにまとめて保存するといった事が考えられるため、ディレクトリを生成(`path.mkdir`)せずに引数に渡しています。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
