### PR TITLE
ModelWrappersDictに`save_state`を実装

### DIFF
--- a/ami/models/utils.py
+++ b/ami/models/utils.py
@@ -56,6 +56,6 @@ class ModelWrappersDict(UserDict[str, ModelWrapper[nn.Module]]):
     def save_state(self, path: Path) -> None:
         """Saves the model parameters to `path`."""
         path.mkdir()
-        for name, model in self.items():
+        for name, wrapper in self.items():
             model_path = path / (name + ".pt")
-            torch.save(model.state_dict(), model_path)
+            torch.save(wrapper.model.state_dict(), model_path)

--- a/ami/models/utils.py
+++ b/ami/models/utils.py
@@ -1,7 +1,9 @@
 """This file contains utility classes."""
 from collections import UserDict
 from enum import StrEnum
+from pathlib import Path
 
+import torch
 import torch.nn as nn
 
 from .model_wrapper import ModelWrapper, ThreadSafeInferenceWrapper
@@ -50,3 +52,10 @@ class ModelWrappersDict(UserDict[str, ModelWrapper[nn.Module]]):
             return self._inference_wrappers_dict
         else:
             return self._inference_wrappers_dict
+
+    def save_state(self, path: Path) -> None:
+        """Saves the model parameters to `path`."""
+        path.mkdir()
+        for name, model in self.items():
+            model_path = path / (name + ".pt")
+            torch.save(model.state_dict(), model_path)

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -28,3 +28,13 @@ class TestWrappersDict:
 
         iwd2 = mwd.inference_wrappers_dict
         assert iwd is iwd2
+
+    def test_save_state(self, tmp_path):
+        models_path = tmp_path / "models"
+        mwd = ModelWrappersDict(
+            a=ModelWrapper(ModelMultiplyP(), "cpu", True), b=ModelWrapper(ModelMultiplyP(), "cpu", False)
+        )
+
+        mwd.save_state(models_path)
+        assert (models_path / "a.pt").exists()
+        assert (models_path / "b.pt").exists()


### PR DESCRIPTION
## 概要

#94 `ModelWrappersDict`に各モデルのパラメータを保存する機能を実装しました。

`<model_name>.pt`という形式のファイル名で保存されます。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
