### PR TITLE
Trainerモジュールに`save_state`を実装

### DIFF
--- a/ami/trainers/base_trainer.py
+++ b/ami/trainers/base_trainer.py
@@ -1,5 +1,6 @@
 """This file contains an abstract base class for all trainers."""
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, TypeAlias
 
 import torch.nn as nn
@@ -215,3 +216,7 @@ class BaseTrainer(ABC):
         self.train()
         self.synchronize()
         self.teardown()
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal state to the `path`."""
+        pass

--- a/ami/trainers/forward_dynamics_trainer.py
+++ b/ami/trainers/forward_dynamics_trainer.py
@@ -1,4 +1,5 @@
 from functools import partial
+from pathlib import Path
 
 import torch
 from torch.distributions import kl_divergence
@@ -6,6 +7,7 @@ from torch.distributions.normal import Normal
 from torch.nn.functional import mse_loss
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from ami.data.buffers.buffer_names import BufferNames
 from ami.data.buffers.causal_data_buffer import CausalDataBuffer
@@ -97,3 +99,8 @@ class ForwardDynamicsTrainer(BaseTrainer):
                 optimizer.step()
 
         self.optimizer_state = optimizer.state_dict()
+
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.optimizer_state, path / "optimizer.pt")

--- a/ami/trainers/image_vae_trainer.py
+++ b/ami/trainers/image_vae_trainer.py
@@ -1,4 +1,5 @@
 from functools import partial
+from pathlib import Path
 
 import torch
 from torch.distributions import kl_divergence
@@ -6,6 +7,7 @@ from torch.distributions.normal import Normal
 from torch.nn.functional import mse_loss
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from ami.data.buffers.buffer_names import BufferNames
 from ami.data.buffers.random_data_buffer import RandomDataBuffer
@@ -83,3 +85,8 @@ class ImageVAETrainer(BaseTrainer):
                 optimizer.step()
 
         self.optimizer_state = optimizer.state_dict()
+
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.optimizer_state, path / "optimizer.pt")

--- a/ami/trainers/ppo_policy_trainer.py
+++ b/ami/trainers/ppo_policy_trainer.py
@@ -1,10 +1,12 @@
 from functools import partial
+from pathlib import Path
 from typing import TypedDict
 
 import torch
 from torch import Tensor
 from torch.distributions import Distribution
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from ..data.buffers.buffer_names import BufferNames
 from ..data.buffers.ppo_trajectory_buffer import PPOTrajectoryBuffer
@@ -165,3 +167,8 @@ class PPOPolicyTrainer(BaseTrainer):
     def teardown(self) -> None:
         super().teardown()
         self.trajectory_data_user.clear()  # Can not use old buffer data because ppo is on-policy method.
+
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.optimizer_state, path / "optimizer.pt")

--- a/ami/trainers/utils.py
+++ b/ami/trainers/utils.py
@@ -1,4 +1,5 @@
 from collections import UserList
+from pathlib import Path
 
 from ..data.utils import DataUsersDict
 from ..models.utils import ModelWrappersDict
@@ -75,3 +76,10 @@ class TrainersList(UserList[BaseTrainer]):
         """
         for trainer in self:
             trainer.attach_data_users_dict(data_users_dict)
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal state to the `path`."""
+        path.mkdir()
+        for i, trainer in enumerate(self):
+            trainer_path = path / str(i)
+            trainer.save_state(trainer_path)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,6 @@
 """This file contains helper objects for testing some features."""
 import platform
+from pathlib import Path
 from typing import Self
 
 import pytest
@@ -76,6 +77,10 @@ class TrainerImpl(BaseTrainer):
         data = dataset[0][0]
         self.model1(data)
         self.model2(data)
+
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(torch.randn(1), path / "state.pt")
 
 
 class AgentImpl(BaseAgent[str, str]):

--- a/tests/trainers/test_forward_dynamics_trainer.py
+++ b/tests/trainers/test_forward_dynamics_trainer.py
@@ -147,3 +147,9 @@ class TestSconv:
         assert trainer.is_trainable() is True
         trainer.trajectory_data_user.clear()
         assert trainer.is_trainable() is False
+
+    def test_save_state(self, trainer: ForwardDynamicsTrainer, tmp_path) -> None:
+        trainer_path = tmp_path / "forward_dynamics"
+        trainer.save_state(trainer_path)
+        assert trainer_path.exists()
+        assert (trainer_path / "optimizer.pt").exists()

--- a/tests/trainers/test_image_vae_trainer.py
+++ b/tests/trainers/test_image_vae_trainer.py
@@ -94,3 +94,9 @@ class TestImageVAETrainer:
         assert trainer.is_trainable() is True
         trainer.image_data_user.clear()
         assert trainer.is_trainable() is False
+
+    def test_save_state(self, trainer: ImageVAETrainer, tmp_path) -> None:
+        trainer_path = tmp_path / "image_vae"
+        trainer.save_state(trainer_path)
+        assert trainer_path.exists()
+        assert (trainer_path / "optimizer.pt").exists()

--- a/tests/trainers/test_ppo_policy_trainer.py
+++ b/tests/trainers/test_ppo_policy_trainer.py
@@ -87,3 +87,9 @@ class TestPPOPolicyTrainer:
         assert trainer.is_trainable() is True
         trainer.run()
         assert trainer.is_trainable() is False
+
+    def test_save_state(self, trainer: PPOPolicyTrainer, tmp_path) -> None:
+        trainer_path = tmp_path / "ppo_policy"
+        trainer.save_state(trainer_path)
+        assert trainer_path.exists()
+        assert (trainer_path / "optimizer.pt").exists()

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -38,3 +38,14 @@ class TestTrainersList:
         trainers.attach_data_users_dict(data_users_dict)
         assert trainer1._data_users_dict is data_users_dict
         assert trainer2._data_users_dict is data_users_dict
+
+    def test_save_state(self, tmp_path):
+        trainer1 = TrainerImpl()
+        trainer2 = TrainerImpl()
+
+        trainers = TrainersList(*[trainer1, trainer2])
+        trainers_path = tmp_path / "trainers"
+        trainers.save_state(trainers_path)
+        assert trainers_path.exists()
+        assert (trainers_path / "0" / "state.pt").exists()
+        assert (trainers_path / "1" / "state.pt").exists()


### PR DESCRIPTION
## 概要

#94 `ami/trainers`モジュールのクラスに`save_state`メソッドを実装しました。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
