### PR TITLE
`data`モジュールに`save_state`を実装

### DIFF
--- a/ami/data/buffers/base_data_buffer.py
+++ b/ami/data/buffers/base_data_buffer.py
@@ -1,6 +1,7 @@
 """This file contains all base data buffer class."""
 import copy
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Self
 
 from torch.utils.data import Dataset
@@ -71,3 +72,7 @@ class BaseDataBuffer(ABC):
             dataset: Dataset object for training.
         """
         raise NotImplementedError
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal state to the `path`."""
+        pass

--- a/ami/data/buffers/random_data_buffer.py
+++ b/ami/data/buffers/random_data_buffer.py
@@ -1,8 +1,11 @@
+import pickle
+from pathlib import Path
 from typing import Self
 
 import numpy as np
 import torch
 from torch.utils.data import TensorDataset
+from typing_extensions import override
 
 from ..step_data import DataKeys, StepData
 from .base_data_buffer import BaseDataBuffer
@@ -41,7 +44,7 @@ class RandomDataBuffer(BaseDataBuffer):
         """
         if self.__current_len < self.__max_len:
             for key in self.__key_list:
-                self.__buffer_dict[key].append(torch.Tensor(step_data[key]))
+                self.__buffer_dict[key].append(torch.Tensor(step_data[key]).cpu())
             self.__current_len += 1
         else:
             replace_index = np.random.randint(0, self.__max_len)
@@ -74,3 +77,11 @@ class RandomDataBuffer(BaseDataBuffer):
         for key in self.__key_list:
             tensor_list.append(torch.stack(self.__buffer_dict[key]))
         return TensorDataset(*tensor_list)
+
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        for key, value in self.__buffer_dict.items():
+            file_name = path / (key.value + ".pkl")
+            with open(file_name, "wb") as f:
+                pickle.dump(value, f)

--- a/ami/data/interfaces.py
+++ b/ami/data/interfaces.py
@@ -1,6 +1,7 @@
 """This file contains the interface class for a data buffer designed for multi-
 threading."""
 import threading
+from pathlib import Path
 from typing import Any, Generic, TypeVar
 
 from torch.utils.data import Dataset
@@ -76,3 +77,8 @@ class ThreadSafeDataUser(Generic[BufferType]):
     def buffer(self) -> BufferType:
         """Returns the reference to the internal buffer."""
         return self._buffer
+
+    def save_state(self, path: Path) -> None:
+        """Saves the buffer state."""
+        self.update()
+        self._buffer.save_state(path)

--- a/ami/data/utils.py
+++ b/ami/data/utils.py
@@ -17,6 +17,7 @@ Assumed usage:
     >>> collector = hydra.utils.instantiate(cfg)
 """
 from collections import UserDict
+from pathlib import Path
 from typing import Any, Self
 
 from .buffers.base_data_buffer import BaseDataBuffer
@@ -27,6 +28,12 @@ from .step_data import StepData
 class DataUsersDict(UserDict[str, ThreadSafeDataUser[Any]]):
     """A class for aggregating `DataUsers` to share them from the inference
     thread to the training thread."""
+
+    def save_state(self, path: Path) -> None:
+        """Saves the internal data buffer."""
+        path.mkdir()
+        for name, user in self.items():
+            user.save_state(path / name)
 
 
 class DataCollectorsDict(UserDict[str, ThreadSafeDataCollector[Any]]):

--- a/tests/data/buffers/test_causal_data_buffer.py
+++ b/tests/data/buffers/test_causal_data_buffer.py
@@ -48,3 +48,11 @@ class TestCausalDataBuffer:
         mod.add(self.step_data)
         mod.add(self.step_data)
         assert isinstance(mod.make_dataset(), TensorDataset)
+
+    def test_save_state(self, tmp_path):
+        mod = CausalDataBuffer.reconstructable_init(self.max_len, self.key_list)
+        mod.add(self.step_data)
+
+        data_dir = tmp_path / "data"
+        mod.save_state(data_dir)
+        assert (data_dir / "observation.pkl").exists()

--- a/tests/data/buffers/test_random_data_buffer.py
+++ b/tests/data/buffers/test_random_data_buffer.py
@@ -48,3 +48,11 @@ class TestRandomDataBuffer:
         mod.add(self.step_data)
         mod.add(self.step_data)
         assert isinstance(mod.make_dataset(), TensorDataset)
+
+    def test_save_state(self, tmp_path):
+        mod = RandomDataBuffer.reconstructable_init(self.max_len, self.key_list)
+        mod.add(self.step_data)
+
+        data_dir = tmp_path / "data"
+        mod.save_state(data_dir)
+        assert (data_dir / "observation.pkl").exists()

--- a/tests/data/test_interfaces.py
+++ b/tests/data/test_interfaces.py
@@ -1,3 +1,6 @@
+import pickle
+from pathlib import Path
+
 import pytest
 import torch
 
@@ -73,3 +76,19 @@ class TestDataCollectorAndUser:
 
         assert collector_buffer is not collector._buffer
         assert user_buffer is not user._buffer
+
+    def test_save_state(
+        self,
+        collector: ThreadSafeDataCollector[DataBufferImpl],
+        user: ThreadSafeDataUser[DataBufferImpl],
+        step_data: StepData,
+        tmp_path: Path,
+    ) -> None:
+        collector.collect(step_data)
+
+        data_path = tmp_path / "data"
+        user.save_state(data_path)
+
+        with open(data_path / "obs.pkl", "rb") as f:
+            for i, obs in enumerate(user.buffer.obs):
+                assert torch.equal(pickle.load(f)[i], obs)

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -7,7 +7,7 @@ from ami.data.utils import DataCollectorsDict, DataUsersDict, ThreadSafeDataColl
 from .buffers.test_base_data_buffer import DataBufferImpl
 
 
-class TestDataCollectorsDict:
+class TestDataCollectorsAndUsersDict:
     @pytest.fixture
     def buffer(self) -> DataBufferImpl:
         return DataBufferImpl.reconstructable_init()
@@ -24,6 +24,10 @@ class TestDataCollectorsDict:
     def collectors_dict(self, collector: ThreadSafeDataCollector) -> DataCollectorsDict:
         return DataCollectorsDict(a=collector)
 
+    @pytest.fixture
+    def users_dict(self, collectors_dict: DataCollectorsDict):
+        return collectors_dict.get_data_users()
+
     def test_collect(self, collectors_dict: DataCollectorsDict, step_data: StepData) -> None:
         collectors_dict.collect(step_data)
 
@@ -33,3 +37,9 @@ class TestDataCollectorsDict:
 
     def test_get_data_users(self, collectors_dict: DataCollectorsDict) -> None:
         assert isinstance(collectors_dict.get_data_users(), DataUsersDict)
+
+    def test_save_state(self, users_dict, tmp_path):
+        data_path = tmp_path / "data"
+
+        users_dict.save_state(data_path)
+        assert (data_path / "a").exists()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,7 @@
 """This file contains helper objects for testing some features."""
+import pickle
 import platform
+from pathlib import Path
 from typing import Self
 
 import pytest
@@ -54,6 +56,11 @@ class DataBufferImpl(BaseDataBuffer):
 
     def make_dataset(self) -> TensorDataset:
         return TensorDataset(torch.stack(self.obs))
+
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        with open(path / "obs.pkl", "wb") as f:
+            pickle.dump(self.obs, f)
 
 
 def skip_if_platform_is_not_linux():


### PR DESCRIPTION
## 概要

#94 DataBuffer, **DataUser**, **DataUsersDict** に`save_state`メソッドを実装しました。
DataCollectorではなく、DataUser上で保存する理由は、保存されるデータの最終的な所有者が`DataUser`であるためです。

そのほか、保持するTensorをcpu上に移すことで、異なる演算デバイス上で`torch.load`を行った時に`map_location`が指定できず読み込めなくなる不具合を修正しました。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
