### PR TITLE
ModelWrappersDictに`load_state`を実装

### DIFF
--- a/ami/models/utils.py
+++ b/ami/models/utils.py
@@ -59,3 +59,9 @@ class ModelWrappersDict(UserDict[str, ModelWrapper[nn.Module]]):
         for name, wrapper in self.items():
             model_path = path / (name + ".pt")
             torch.save(wrapper.model.state_dict(), model_path)
+
+    def load_state(self, path: Path) -> None:
+        """Loads the model parameters from `path`."""
+        for name, wrapper in self.items():
+            model_path = path / (name + ".pt")
+            wrapper.model.load_state_dict(torch.load(model_path, map_location=wrapper.device))

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -1,5 +1,4 @@
 import torch
-import torch.utils
 
 from ami.models.model_wrapper import ModelWrapper
 from ami.models.utils import InferenceWrappersDict, ModelWrappersDict


### PR DESCRIPTION
## 概要

#95 モデルのパラメータ読込機能を追加しました。テストはセーブとロードがセットになっていた方がやりやすかったのでそのように修正しました。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
