### PR TITLE
`pause`と`resume`のイベントコールバックの呼び出し処理を実装

### DIFF
--- a/ami/threads/background_thread.py
+++ b/ami/threads/background_thread.py
@@ -28,6 +28,8 @@ class BackgroundThread(BaseThread):
             ThreadTypes.MAIN,
             SharedObjectNames.THREAD_COMMAND_HANDLERS,
         )[self.THREAD_TYPE]
+        self.thread_command_handler.register_on_paused_callback(self.on_paused)
+        self.thread_command_handler.register_on_resumed_callback(self.on_resumed)
 
     def start(self) -> None:
         self.logger.info("Starts background thread.")
@@ -39,3 +41,17 @@ class BackgroundThread(BaseThread):
     def join(self) -> None:
         self._thread.join()
         self.logger.info("Joined background thread.")
+
+    def on_paused(self) -> None:
+        """Callback function to be called when the system is paused.
+
+        This callback is called before `on_resumed` callback.
+        """
+        pass
+
+    def on_resumed(self) -> None:
+        """Callback function to be called when the system is resumed.
+
+        This callback is called after `on_paused` callback.
+        """
+        pass

--- a/ami/threads/background_thread.py
+++ b/ami/threads/background_thread.py
@@ -28,8 +28,8 @@ class BackgroundThread(BaseThread):
             ThreadTypes.MAIN,
             SharedObjectNames.THREAD_COMMAND_HANDLERS,
         )[self.THREAD_TYPE]
-        self.thread_command_handler.register_on_paused_callback(self.on_paused)
-        self.thread_command_handler.register_on_resumed_callback(self.on_resumed)
+        self.thread_command_handler.on_paused = self.on_paused
+        self.thread_command_handler.on_resumed = self.on_resumed
 
     def start(self) -> None:
         self.logger.info("Starts background thread.")

--- a/ami/threads/thread_control.py
+++ b/ami/threads/thread_control.py
@@ -130,13 +130,13 @@ class ThreadCommandHandler:
             bool: True if the thread should continue executing, False if the thread is shutting down.
         """
         paused = False
-        if self._controller.is_paused():
+        if self._controller.is_paused():  # Entering system state: `pause`
             self.on_paused()
             paused = True
 
-        self.stop_if_paused()
+        self.stop_if_paused()  # Blocking if system is `paused`
 
-        if paused:
+        if paused:  # Exiting system state: `pause`, entering `resume`.
             paused = False
             self.on_resumed()
 

--- a/tests/threads/test_background_thread.py
+++ b/tests/threads/test_background_thread.py
@@ -38,6 +38,18 @@ class TestBackgroundThread:
 
     def test_thread_command_handler(self, thread_objects):
         _, it, tt = thread_objects
+        it: BackgroundThread
+        tt: BackgroundThread
         assert isinstance(it.thread_command_handler, ThreadCommandHandler)
         assert isinstance(tt.thread_command_handler, ThreadCommandHandler)
         assert it.thread_command_handler is not tt.thread_command_handler, "must be other instance."
+
+        assert it.on_paused in it.thread_command_handler._on_paused_callbacks
+        assert it.on_paused not in tt.thread_command_handler._on_paused_callbacks
+        assert it.on_resumed in it.thread_command_handler._on_resumed_callbacks
+        assert it.on_resumed not in tt.thread_command_handler._on_paused_callbacks
+
+        assert tt.on_paused in tt.thread_command_handler._on_paused_callbacks
+        assert tt.on_paused not in it.thread_command_handler._on_paused_callbacks
+        assert tt.on_resumed in tt.thread_command_handler._on_resumed_callbacks
+        assert tt.on_resumed not in it.thread_command_handler._on_paused_callbacks

--- a/tests/threads/test_background_thread.py
+++ b/tests/threads/test_background_thread.py
@@ -44,12 +44,7 @@ class TestBackgroundThread:
         assert isinstance(tt.thread_command_handler, ThreadCommandHandler)
         assert it.thread_command_handler is not tt.thread_command_handler, "must be other instance."
 
-        assert it.on_paused in it.thread_command_handler._on_paused_callbacks
-        assert it.on_paused not in tt.thread_command_handler._on_paused_callbacks
-        assert it.on_resumed in it.thread_command_handler._on_resumed_callbacks
-        assert it.on_resumed not in tt.thread_command_handler._on_paused_callbacks
-
-        assert tt.on_paused in tt.thread_command_handler._on_paused_callbacks
-        assert tt.on_paused not in it.thread_command_handler._on_paused_callbacks
-        assert tt.on_resumed in tt.thread_command_handler._on_resumed_callbacks
-        assert tt.on_resumed not in it.thread_command_handler._on_paused_callbacks
+        assert it.on_paused == it.thread_command_handler.on_paused
+        assert tt.on_paused == tt.thread_command_handler.on_paused
+        assert it.on_resumed == it.thread_command_handler.on_resumed
+        assert tt.on_resumed == tt.thread_command_handler.on_resumed

--- a/tests/threads/test_thread_control.py
+++ b/tests/threads/test_thread_control.py
@@ -29,6 +29,18 @@ class Counter:
             self._v += 1
 
 
+class PauseResumeEventLog:
+    def __init__(self) -> None:
+        self.num_paused = 0
+        self.num_resumed = 0
+
+    def on_paused(self) -> None:
+        self.num_paused += 1
+
+    def on_resumed(self) -> None:
+        self.num_resumed += 1
+
+
 def infinity_increment_thread(counter: Counter, handler: ThreadCommandHandler) -> None:
     """テスト用のバックグラウンドスレッド。カウンタを無限に増加。"""
     while handler.manage_loop():
@@ -60,12 +72,16 @@ def test_manage_loop() -> None:
     controller = ThreadController()
     handler = ThreadCommandHandler(controller, check_resume_interval=10)
     counter = Counter()
+    pause_resume_event_log = PauseResumeEventLog()  # pause/resumeのイベント呼び出し記録用
+    handler.register_on_paused_callback(pause_resume_event_log.on_paused)
+    handler.register_on_resumed_callback(pause_resume_event_log.on_resumed)
 
     thread = threading.Thread(target=infinity_increment_thread, args=(counter, handler))
     thread.start()
 
     # Backgroundスレッドの一時停止が期待通り行われているか
     # 一時停止した -> カウンタが停止している。
+    # また、`pause`イベントコールバックが呼び出された。
     controller.pause()
     time.sleep(0.01)
     value = counter.value
@@ -73,9 +89,11 @@ def test_manage_loop() -> None:
     not_changed_value = counter.value
 
     assert value == not_changed_value
+    assert pause_resume_event_log.num_paused == 1
 
     # Backgroundスレッドの再開処理が期待通り行われているか
     # 再開した -> カウンタが増加している
+    # また、`resume`イベントコールバックが呼び出された
     controller.resume()
     time.sleep(0.01)
     value = counter.value
@@ -83,6 +101,7 @@ def test_manage_loop() -> None:
     changed_value = counter.value
 
     assert value < changed_value
+    assert pause_resume_event_log.num_resumed == 1
 
     # 一時停止中でも終了命令を処理できるか。
     controller.pause()
@@ -90,6 +109,10 @@ def test_manage_loop() -> None:
     controller.shutdown()
 
     thread.join()
+
+    # Shutdownの際に`resume`(復帰）が呼ばれているか
+    assert pause_resume_event_log.num_paused == 2
+    assert pause_resume_event_log.num_resumed == 2
 
 
 def test_create_handlers():

--- a/tests/threads/test_thread_control.py
+++ b/tests/threads/test_thread_control.py
@@ -73,8 +73,8 @@ def test_manage_loop() -> None:
     handler = ThreadCommandHandler(controller, check_resume_interval=10)
     counter = Counter()
     pause_resume_event_log = PauseResumeEventLog()  # pause/resumeのイベント呼び出し記録用
-    handler.register_on_paused_callback(pause_resume_event_log.on_paused)
-    handler.register_on_resumed_callback(pause_resume_event_log.on_resumed)
+    handler.on_paused = pause_resume_event_log.on_paused
+    handler.on_resumed = pause_resume_event_log.on_resumed
 
     thread = threading.Thread(target=infinity_increment_thread, args=(counter, handler))
     thread.start()


### PR DESCRIPTION
## 概要

#130 ThreadCommandHandlerにコールバックを登録し、**pause/resumeされるスレッド上で同期的に呼び出される**ように実装しました。すなわち、そのスレッドクラスの`on_paused`, `on_resumed`はスレッドセーフであり、スレッドが動作中に割り込むことはありません。よって、Systemが`pause`し、すぐに`resume`した場合などは、イベント関数が呼び出されない場合があります。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
