### PR TITLE
モデルラッパーの`infer`のダックタイピングをモデルラッパーの`infer`のダックタイピングを静的型付けに修正静的型付けに修正

### DIFF
--- a/ami/models/model_wrapper.py
+++ b/ami/models/model_wrapper.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 import copy
 import threading
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Protocol, Self, TypeVar, runtime_checkable
 
 import torch
 import torch.nn as nn
 
 ModuleType = TypeVar("ModuleType", bound=nn.Module)
+
+
+@runtime_checkable
+class SupportsToDevice(Protocol):
+    """To check supporting `to(device)` method."""
+
+    def to(self, device: torch.device) -> Self:
+        ...
 
 
 class ModelWrapper(nn.Module, Generic[ModuleType]):
@@ -63,12 +71,12 @@ class ModelWrapper(nn.Module, Generic[ModuleType]):
         device = self.device
         new_args, new_kwds = [], {}
         for i in args:
-            if isinstance(i, torch.Tensor):
+            if isinstance(i, SupportsToDevice):
                 i = i.to(device)
             new_args.append(i)
 
         for k, v in kwds.items():
-            if isinstance(v, torch.Tensor):
+            if isinstance(v, SupportsToDevice):
                 v = v.to(device)
             new_kwds[k] = v
 


### PR DESCRIPTION
## 概要

`typing.Protocol`を用いてダックタイピングの静的チェックを可能にしました。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
