### PR TITLE
value lossの計算の修正案

### DIFF
--- a/ami/data/buffers/ppo_trajectory_buffer.py
+++ b/ami/data/buffers/ppo_trajectory_buffer.py
@@ -62,8 +62,7 @@ class PPOTrajectoryBuffer(CausalDataBuffer):
 
         advantages = compute_advantage(rewards, values, final_next_value, self.gamma, self.gae_lambda)
 
-        next_values = raw_values[1:]
-        value_targets = rewards + self.gamma * next_values
+        value_targets = advantages
 
         return TensorDataset(observations, actions, logprobs, advantages, value_targets, values)
 

--- a/ami/data/buffers/ppo_trajectory_buffer.py
+++ b/ami/data/buffers/ppo_trajectory_buffer.py
@@ -61,9 +61,11 @@ class PPOTrajectoryBuffer(CausalDataBuffer):
         values = raw_values[:-1]
 
         advantages = compute_advantage(rewards, values, final_next_value, self.gamma, self.gae_lambda)
-        returns = advantages + values
 
-        return TensorDataset(observations, actions, logprobs, advantages, returns, values)
+        next_values = raw_values[1:]
+        value_targets = rewards + self.gamma * next_values
+
+        return TensorDataset(observations, actions, logprobs, advantages, value_targets, values)
 
 
 def compute_advantage(


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
~~value lossをTD誤差に変更~~
~~安定して動作するのを確認~~
~~valueが増大する傾向にある、要確認~~
がvalue targetsが
* advantages + values
  - 行動エントロピーがほぼ0に張り付く、行き止まりから抜け出せない
* rewards + gamma * next_values (TD誤差)
  - 行動エントロピーは下がるが0まではいかない、行き止まりで止まるがしばらくすると抜け出せることもある
* advantage
  - 行動エントロピーはゆるやかに下がっていくがある程度の大きさで安定する

ひとまずadvantageを選択したい　良い方法があれば後で変更

advantage選択時のグラフ推移
![スクリーンショット 2024-04-21 150652](https://github.com/MLShukai/ami/assets/46291391/c1cacd76-37cd-4edb-b97b-72e120cf1e18)


## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
