### PR TITLE
並列システムが動作中にチェックポイントを保存する機能を追加

### DIFF
--- a/ami/threads/thread_control.py
+++ b/ami/threads/thread_control.py
@@ -64,6 +64,7 @@ class ThreadController:
         """Sets the resume flag."""
         if self._save_checkpoint_event.is_set():
             self._logger.info("Ignored 'resume' call because the checkpoint saving is beging executed.")
+            return
         self._resume_event.set()
 
     def pause(self) -> None:

--- a/ami/threads/thread_control.py
+++ b/ami/threads/thread_control.py
@@ -169,7 +169,6 @@ class ThreadCommandHandler:
         self._controller = controller
         self.check_resume_interval = check_resume_interval
         self._loop_pause_event = threading.Event()
-        self._loop_pause_event.clear()
 
     def is_active(self) -> bool:
         """Checks if the managed thread should continue running."""

--- a/tests/threads/test_thread_control.py
+++ b/tests/threads/test_thread_control.py
@@ -11,7 +11,6 @@ import pytest
 from pytest_mock import MockerFixture
 
 from ami.threads.thread_control import (
-    Checkpointing,
     ThreadCommandHandler,
     ThreadController,
     ThreadTypes,
@@ -150,12 +149,10 @@ def test_wait_for_loop_pause():
 
 def test_save_checkpoint(tmp_path, mocker: MockerFixture) -> None:
     controller = ThreadController()
-    checkpointing = Checkpointing(tmp_path)
-    controller.checkpointing = checkpointing
     mock_save_checkpoint = mocker.Mock()
     ckpt_path = tmp_path / "test.ckpt"
     mock_save_checkpoint.return_value = ckpt_path
-    controller.checkpointing.save_checkpoint = mock_save_checkpoint
+    controller.save_checkpoint_callback = mock_save_checkpoint
 
     for hdlr in controller.handlers.values():
         threading.Timer(0.1, hdlr._loop_pause_event.set).start()


### PR DESCRIPTION
## 概要

#168 スレッドの一時停止を待つタイムアウト秒数は適当に3分としました。依存性を抽出し、`Checkpointing`クラスではなくコールバックを指定する形式としました。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
