### PR TITLE
PredictionErrorRewardクラスを実装

### DIFF
--- a/configs/interaction/agent/curiosity_image_ppo.yaml
+++ b/configs/interaction/agent/curiosity_image_ppo.yaml
@@ -11,3 +11,8 @@ logger:
   _target_: ami.tensorboard_loggers.TimeIntervalLogger
   log_dir: ${paths.tensorboard_dir}/agent
   log_every_n_seconds: 0
+
+reward:
+  _target_: ami.interactions.agents.curiosity_image_ppo_agent.PredictionErrorReward
+  scale: 0.001
+  shift: 0.0

--- a/configs/interaction/agent/curiosity_image_ppo.yaml
+++ b/configs/interaction/agent/curiosity_image_ppo.yaml
@@ -14,5 +14,5 @@ logger:
 
 reward:
   _target_: ami.interactions.agents.curiosity_image_ppo_agent.PredictionErrorReward
-  scale: 0.001
+  scale: 1.0
   shift: 0.0


### PR DESCRIPTION
## 概要

#172 報酬計算を行うクラスを分離し、スケールやシフトを可能にしました。
PrimitiveAMIと比較して、即時報酬の値が3~5程度で大きかったため、0.001を`scale`に指定して以前のぱみきゅーと同程度のオーダーにしました。

~Policyのエントロピーが0に収束してしまう件ですが、Forward Dynamicsが予測可能になる前に収益が発散してしまったことが原因と考えられます。方策勾配法ベースの手法は勾配に収益やアドバンテージの値を乗算して更新はばを推定する関係上、初期に非常に大きく更新され、その結果行動が一定になってしまう、と考えました。~

長時間動作させると 0にエントロピーは収束しました。
<img width="656" alt="スクリーンショット 2024-04-25 午後0 40 38" src="https://github.com/MLShukai/ami/assets/59220704/ce9e3484-0410-4f05-9db3-35b2ca9bdbfe">

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
