### PR TITLE
ThreadSafeFlagを追加

### DIFF
--- a/ami/threads/utils.py
+++ b/ami/threads/utils.py
@@ -1,0 +1,32 @@
+import threading
+
+
+class ThreadSafeFlag:
+    """A thread-safe flag that can be set, cleared, or checked."""
+
+    def __init__(self) -> None:
+        """Initialize the flag as False and set up a reentrant lock."""
+        self._lock = threading.RLock()
+        self._flag = False
+
+    def clear(self) -> None:
+        """Clear the flag to False, thread-safely."""
+        with self._lock:
+            self._flag = False
+
+    def is_set(self) -> bool:
+        """Return True if the flag is set, thread-safely."""
+        with self._lock:
+            return self._flag
+
+    def set(self) -> None:
+        """Set the flag to True, thread-safely."""
+        with self._lock:
+            self._flag = True
+
+    def get(self) -> bool:
+        """Return the current value of the flag and clear it, thread-safely."""
+        with self._lock:
+            value = self._flag
+            self.clear()
+            return value

--- a/ami/threads/utils.py
+++ b/ami/threads/utils.py
@@ -24,7 +24,7 @@ class ThreadSafeFlag:
         with self._lock:
             self._flag = True
 
-    def get(self) -> bool:
+    def take(self) -> bool:
         """Return the current value of the flag and clear it, thread-safely."""
         with self._lock:
             value = self._flag

--- a/tests/threads/test_utils.py
+++ b/tests/threads/test_utils.py
@@ -20,8 +20,8 @@ class TestThreadSafeFlag:
         flag.clear()
         assert flag.is_set() is False, "Flag should be cleared to False"
 
-    def test_get(self, flag):
-        assert flag.get() is False
+    def test_take(self, flag):
+        assert flag.take() is False
         flag.set()
-        assert flag.get() is True, "Get should return True"
+        assert flag.take() is True, "Get should return True"
         assert flag.is_set() is False, "Flag should be cleared after get"

--- a/tests/threads/test_utils.py
+++ b/tests/threads/test_utils.py
@@ -1,0 +1,27 @@
+import pytest
+
+from ami.threads.utils import ThreadSafeFlag
+
+
+class TestThreadSafeFlag:
+    @pytest.fixture
+    def flag(self) -> ThreadSafeFlag:
+        return ThreadSafeFlag()
+
+    def test_is_set_when_inital(self, flag):
+        assert flag.is_set() is False, "Flag should be initially False"
+
+    def test_set(self, flag):
+        flag.set()
+        assert flag.is_set() is True, "Flag should be set to True"
+
+    def test_clear(self, flag):
+        flag.set()
+        flag.clear()
+        assert flag.is_set() is False, "Flag should be cleared to False"
+
+    def test_get(self, flag):
+        assert flag.get() is False
+        flag.set()
+        assert flag.get() is True, "Get should return True"
+        assert flag.is_set() is False, "Flag should be cleared after get"


### PR DESCRIPTION
## 概要

#181 に関連して、WebApiHandlerが取得したコマンドのフラグ処理を行うためのクラスを実装しました。
`threading.Event`と異なる点として、`take`メソッドによって内部のフラグがリセットされる点です。これにより、命令を一つの命令をスレッドセーフに受け取り、クリアすることができます。

想定される使われ方

```py
class WebApiHandler
    ...
    def receive_shutdown(self) -> bool:
        return self._shutdown_flag.take()

class MainThread:
    def worker(self):
        while True:
             if self.web_api_handler.reveive_shutdown():
                 self.thread_controller.shutdown()
```

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
