### PR TITLE
TensorBoardへモデルパラメータ数を記録

### DIFF
--- a/scripts/launch.py
+++ b/scripts/launch.py
@@ -14,7 +14,7 @@ from ami.hydra_instantiators import (
 )
 from ami.interactions.interaction import Interaction
 from ami.logger import get_main_thread_logger
-from ami.models.utils import ModelWrappersDict
+from ami.models.utils import ModelWrappersDict, create_model_parameter_count_dict
 from ami.omegaconf_resolvers import register_custom_resolvers
 from ami.tensorboard_loggers import TensorBoardLogger
 from ami.threads import (
@@ -82,6 +82,7 @@ def main(cfg: DictConfig) -> None:
         "data": cfg.data_collectors,
         "models": cfg.models,
         "trainers": cfg.trainers,
+        "param_count": create_model_parameter_count_dict(models),
     }
     tensorboard_logger.log_hyperparameters(hparams_dict)
 


### PR DESCRIPTION
## 概要

#186 全て、およびそれぞれモデルのパラメータ数の合計、学習可能数、凍結数をTensorBoardへ記録しました。

## 変更内容
<img width="891" alt="スクリーンショット 2024-05-03 午後1 37 07" src="https://github.com/MLShukai/ami/assets/59220704/a5ca327a-2772-40bc-ac80-82cf27ef9617">

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->


## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
