### PR TITLE
学習スレッドや推論スレッドで実行時間のログ出力処理を追加

### DIFF
--- a/ami/threads/training_thread.py
+++ b/ami/threads/training_thread.py
@@ -44,7 +44,9 @@ class TrainingThread(BackgroundThread):
             trainer = self.trainers.get_next_trainer()
             if trainer.is_trainable():
                 self.logger.info(f"Running: {type(trainer).__name__} ...")
+                start = time.perf_counter()
                 trainer.run()
+                self.logger.debug(f"Training time: {time.perf_counter() - start:.2f} [s].")
 
             time.sleep(self.training_interval)  # See Issue: https://github.com/MLShukai/ami/issues/175
 


### PR DESCRIPTION
## 概要

InferenceThreadの1ステップあたりにかかる時間やTrainingの実行時間を記録する処理を追記しました。
実動作を確認しました。

```
[2024-05-10 20:27:58,028][training.TrainingThread][INFO] - Running: ImageVAETrainer ...
[2024-05-10 20:28:00,733][training.TrainingThread][DEBUG] - Training time: 2.71 [s].
[2024-05-10 20:28:00,733][training.TrainingThread][INFO] - Running: ImageVAETrainer ...
[2024-05-10 20:28:01,182][inference.InferenceThread][DEBUG] - Step time: 1.026e-01 ± 1.976e-03 [s] in 585 steps.
```

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
