### PR TITLE
指定した数 データバッファが更新された場合に学習を実行する機能

### DIFF
--- a/ami/data/buffers/causal_data_buffer.py
+++ b/ami/data/buffers/causal_data_buffer.py
@@ -15,6 +15,8 @@ from .base_data_buffer import BaseDataBuffer
 class CausalDataBuffer(BaseDataBuffer):
     """A data buffer which preserve data order."""
 
+    new_data_count: int  # Count of new data added since the last `make_dataset`.
+
     def __init__(self, max_len: int, key_list: list[DataKeys | str]) -> None:
         """Initializes data buffer.
 

--- a/ami/data/buffers/random_data_buffer.py
+++ b/ami/data/buffers/random_data_buffer.py
@@ -15,6 +15,8 @@ from .base_data_buffer import BaseDataBuffer
 class RandomDataBuffer(BaseDataBuffer):
     """A data buffer which does not preserve data order."""
 
+    new_data_count: int  # Count of new data added since the last `make_dataset`.
+
     def __init__(self, max_len: int, key_list: list[DataKeys | str]) -> None:
         """Initializes data buffer.
 

--- a/configs/trainers/forward_dynamics/default.yaml
+++ b/configs/trainers/forward_dynamics/default.yaml
@@ -22,3 +22,4 @@ observation_encoder_name: image_encoder
 device: ${devices.0}
 max_epochs: 3
 minimum_dataset_size: ${.partial_dataloader.batch_size}
+minimum_new_data_count: 128 # From primitive AMI

--- a/configs/trainers/image_vae/default.yaml
+++ b/configs/trainers/image_vae/default.yaml
@@ -20,3 +20,4 @@ kl_coef: 0.01
 device: ${devices.0}
 max_epochs: 3
 minimum_dataset_size: ${.partial_dataloader.batch_size}
+minimum_new_data_count: 128 # From primitive ami.

--- a/tests/data/buffers/test_causal_data_buffer.py
+++ b/tests/data/buffers/test_causal_data_buffer.py
@@ -14,6 +14,7 @@ class TestCausalDataBuffer:
     def test__init__(self):
         mod = CausalDataBuffer.reconstructable_init(self.max_len, self.key_list)
         assert len(mod) == 0
+        assert mod.new_data_count == 0
 
     def test_add(self):
         mod = CausalDataBuffer.reconstructable_init(self.max_len, self.key_list)
@@ -21,12 +22,14 @@ class TestCausalDataBuffer:
         mod.add(self.step_data)
         mod.add(self.step_data)
         assert len(mod) == 3
+        assert mod.new_data_count == 3
 
     def test_add_overflow(self):
         mod = CausalDataBuffer.reconstructable_init(self.max_len, self.key_list)
         for _ in range(32):
             mod.add(self.step_data)
         assert len(mod) == self.max_len
+        assert mod.new_data_count == self.max_len
 
     def test_concatenate(self):
         mod1 = CausalDataBuffer.reconstructable_init(self.max_len, self.key_list)
@@ -41,6 +44,7 @@ class TestCausalDataBuffer:
         mod2.add(self.step_data)
         mod1.concatenate(mod2)
         assert len(mod1) == 8
+        assert mod1.new_data_count == 8
 
     def test_make_dataset(self):
         mod = CausalDataBuffer.reconstructable_init(self.max_len, self.key_list)
@@ -48,6 +52,7 @@ class TestCausalDataBuffer:
         mod.add(self.step_data)
         mod.add(self.step_data)
         assert isinstance(mod.make_dataset(), TensorDataset)
+        assert mod.new_data_count == 0
 
     def test_save_and_load_state(self, tmp_path):
         mod = CausalDataBuffer.reconstructable_init(self.max_len, self.key_list)
@@ -56,11 +61,14 @@ class TestCausalDataBuffer:
         data_dir = tmp_path / "data"
         mod.save_state(data_dir)
         assert (data_dir / "observation.pkl").exists()
+        assert (data_dir / "state.json").exists()
 
         saved_buffer_dataset = mod.make_dataset()
 
         mod = mod.new()
+        assert mod.new_data_count == 0
         mod.load_state(data_dir)
+        assert mod.new_data_count == 1
 
         loaded_buffer_dataset = mod.make_dataset()
 

--- a/tests/data/buffers/test_random_data_buffer.py
+++ b/tests/data/buffers/test_random_data_buffer.py
@@ -14,6 +14,7 @@ class TestRandomDataBuffer:
     def test__init__(self):
         mod = RandomDataBuffer.reconstructable_init(self.max_len, self.key_list)
         assert len(mod) == 0
+        assert mod.new_data_count == 0
 
     def test_add(self):
         mod = RandomDataBuffer.reconstructable_init(self.max_len, self.key_list)
@@ -21,12 +22,14 @@ class TestRandomDataBuffer:
         mod.add(self.step_data)
         mod.add(self.step_data)
         assert len(mod) == 3
+        assert mod.new_data_count == 3
 
     def test_add_overflow(self):
         mod = RandomDataBuffer.reconstructable_init(self.max_len, self.key_list)
         for _ in range(32):
             mod.add(self.step_data)
         assert len(mod) == self.max_len
+        assert mod.new_data_count == self.max_len
 
     def test_concatenate(self):
         mod1 = RandomDataBuffer.reconstructable_init(self.max_len, self.key_list)
@@ -41,6 +44,7 @@ class TestRandomDataBuffer:
         mod2.add(self.step_data)
         mod1.concatenate(mod2)
         assert len(mod1) == 8
+        assert mod1.new_data_count == 8
 
     def test_make_dataset(self):
         mod = RandomDataBuffer.reconstructable_init(self.max_len, self.key_list)
@@ -48,6 +52,7 @@ class TestRandomDataBuffer:
         mod.add(self.step_data)
         mod.add(self.step_data)
         assert isinstance(mod.make_dataset(), TensorDataset)
+        assert mod.new_data_count == 0
 
     def test_save_and_load_state(self, tmp_path):
         mod = RandomDataBuffer.reconstructable_init(self.max_len, self.key_list)
@@ -56,11 +61,14 @@ class TestRandomDataBuffer:
         data_dir = tmp_path / "data"
         mod.save_state(data_dir)
         assert (data_dir / "observation.pkl").exists()
+        assert (data_dir / "state.json").exists()
 
         saved_buffer_dataset = mod.make_dataset()
 
         mod = mod.new()
+        assert mod.new_data_count == 0
         mod.load_state(data_dir)
+        assert mod.new_data_count == 1
 
         loaded_buffer_dataset = mod.make_dataset()
 

--- a/tests/trainers/test_forward_dynamics_trainer.py
+++ b/tests/trainers/test_forward_dynamics_trainer.py
@@ -145,7 +145,12 @@ class TestSconv:
         logger,
     ):
         trainer = ForwardDynamicsTrainer(
-            partial_dataloader, partial_optimizer, device, logger, observation_encoder_name=ModelNames.IMAGE_ENCODER
+            partial_dataloader,
+            partial_optimizer,
+            device,
+            logger,
+            observation_encoder_name=ModelNames.IMAGE_ENCODER,
+            minimum_new_data_count=2,
         )
         trainer.attach_model_wrappers_dict(forward_dynamics_wrappers_dict)
         trainer.attach_data_users_dict(trajectory_buffer_dict.get_data_users())
@@ -158,6 +163,12 @@ class TestSconv:
         assert trainer.is_trainable() is True
         trainer.trajectory_data_user.clear()
         assert trainer.is_trainable() is False
+
+    def test_is_new_data_available(self, trainer: ForwardDynamicsTrainer):
+        trainer.trajectory_data_user.update()
+        assert trainer._is_new_data_available() is True
+        trainer.run()
+        assert trainer._is_new_data_available() is False
 
     def test_save_and_load_state(self, trainer: ForwardDynamicsTrainer, tmp_path, mocker) -> None:
         trainer_path = tmp_path / "forward_dynamics"

--- a/tests/trainers/test_image_vae_trainer.py
+++ b/tests/trainers/test_image_vae_trainer.py
@@ -88,7 +88,7 @@ class TestImageVAETrainer:
         device: torch.device,
         logger: StepIntervalLogger,
     ) -> ImageVAETrainer:
-        trainer = ImageVAETrainer(partial_dataloader, partial_optimizer, device, logger)
+        trainer = ImageVAETrainer(partial_dataloader, partial_optimizer, device, logger, minimum_new_data_count=1)
         trainer.attach_model_wrappers_dict(encoder_decoder_wrappers_dict)
         trainer.attach_data_users_dict(image_buffer_dict.get_data_users())
         return trainer
@@ -100,6 +100,12 @@ class TestImageVAETrainer:
         assert trainer.is_trainable() is True
         trainer.image_data_user.clear()
         assert trainer.is_trainable() is False
+
+    def test_is_new_data_available(self, trainer: ImageVAETrainer):
+        trainer.image_data_user.update()
+        assert trainer._is_new_data_available() is True
+        trainer.run()
+        assert trainer._is_new_data_available() is False
 
     def test_save_and_load_state(self, trainer: ImageVAETrainer, tmp_path, mocker) -> None:
         trainer_path = tmp_path / "image_vae"


### PR DESCRIPTION
## 概要

#190 PrimitiveAMIと学習の形式を一致させ、新規データ数が一定以上増えた場合に学習を実行する機能を実装しました。これにより、更新されないデータセットに過学習することを調整できると考えます。

BaseDataBufferへの実装を考えましたが断念しました。 #190 

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
