### PR TITLE
設定ファイル間で共有される値だけを保持するファイルを追加

### DIFF
--- a/configs/interaction/environment/dummy_image_io.yaml
+++ b/configs/interaction/environment/dummy_image_io.yaml
@@ -3,7 +3,10 @@ observation_generator:
   _target_: ami.interactions.environments.dummy_environment.SameObservationGenerator
   observation:
     _target_: torch.zeros
-    _args_: [3, 84, 84] # channels, height, width.
+    _args_:
+      - ${shared.image_channels}
+      - ${shared.image_height}
+      - ${shared.image_width}
 
 action_checker:
   _target_: ami.interactions.environments.dummy_environment.ActionTypeChecker

--- a/configs/interaction/environment/vrchat_image_discrete.yaml
+++ b/configs/interaction/environment/vrchat_image_discrete.yaml
@@ -3,8 +3,8 @@ _target_: ami.interactions.environments.sensor_actuator_env.SensorActuatorEnv
 sensor:
   _target_: ami.interactions.environments.sensors.opencv_image_sensor.OpenCVImageSensor
   camera_index: 0
-  width: 84
-  height: 84
+  width: ${shared.image_width}
+  height: ${shared.image_height}
   base_fps: 60
 
 actuator:

--- a/configs/launch.yaml
+++ b/configs/launch.yaml
@@ -4,6 +4,7 @@
 # order of defaults determines the order in which configs override each other
 defaults:
   - _self_
+
   - interaction: default
   - data_collectors: image
   - models: image_vae
@@ -17,6 +18,9 @@ defaults:
 
   # experiment configs allow for version control of specific hyperparameters
   - experiment: null
+
+  # You can specify configuration values that are shared among all config files.
+  - shared: default
 
 task_name: image_encoding
 

--- a/configs/models/image_vae.yaml
+++ b/configs/models/image_vae.yaml
@@ -4,9 +4,9 @@ image_encoder:
   has_inference: True
   model:
     _target_: ami.models.vae.Conv2dEncoder
-    height: 84
-    width: 84
-    channels: 3
+    height: ${shared.image_height}
+    width: ${shared.image_width}
+    channels: ${shared.image_channels}
     latent_dim: 512 # From primitive AMI.
 
 image_decoder:

--- a/configs/models/image_vae_sconv_discrete_ppo.yaml
+++ b/configs/models/image_vae_sconv_discrete_ppo.yaml
@@ -4,9 +4,9 @@ image_encoder:
   has_inference: True
   model:
     _target_: ami.models.vae.Conv2dEncoder
-    height: ${interaction.environment.sensor.height}
-    width: ${interaction.environment.sensor.width}
-    channels: 3
+    height: ${shared.image_height}
+    width: ${shared.image_width}
+    channels: ${shared.image_channels}
     latent_dim: 512 # From primitive AMI.
 
 image_decoder:

--- a/configs/shared/default.yaml
+++ b/configs/shared/default.yaml
@@ -1,0 +1,5 @@
+# You can specify configuration values that are shared among all config files.
+
+image_height: 84
+image_width: 84
+image_channels: 3


### PR DESCRIPTION
## 概要

config内に`shared`セクションを追加し、そこにInteractionやModel, Trainerといった複数の設定ファイルで共有される値を記述するように修正しました。例えばModelがInteractionの設定値を参照しているといった状況で、そこを`shared`セクションに記述することで、Interactionの設定の構造変化Modelが考えなくても良いようにします。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
