### PR TITLE
VAEにBatchNormを追加

### DIFF
--- a/ami/models/vae.py
+++ b/ami/models/vae.py
@@ -24,9 +24,9 @@ class Decoder(ABC, nn.Module):
 
 
 class Conv2dEncoder(Encoder):
-    def __init__(self, height: int, width: int, channels: int, latent_dim: int) -> None:
+    def __init__(self, height: int, width: int, channels: int, latent_dim: int, do_batchnorm: bool = False) -> None:
         super().__init__()
-        self.conv_net = SmallConvNet(height, width, channels, latent_dim)
+        self.conv_net = SmallConvNet(height, width, channels, latent_dim, do_batchnorm=do_batchnorm)
         self.linear_mu = nn.Linear(latent_dim, latent_dim)
         self.linear_sigma = nn.Linear(latent_dim, latent_dim)
 
@@ -40,9 +40,9 @@ class Conv2dEncoder(Encoder):
 
 
 class Conv2dDecoder(Decoder):
-    def __init__(self, height: int, width: int, channels: int, latent_dim: int) -> None:
+    def __init__(self, height: int, width: int, channels: int, latent_dim: int, do_batchnorm: bool = False) -> None:
         super().__init__()
-        self.deconv_net = SmallDeconvNet(height, width, channels, latent_dim)
+        self.deconv_net = SmallDeconvNet(height, width, channels, latent_dim, do_batchnorm=do_batchnorm)
 
     def forward(self, z: Tensor) -> Tensor:
         rec_img: Tensor = self.deconv_net(z)

--- a/configs/models/image_vae_sconv_discrete_ppo.yaml
+++ b/configs/models/image_vae_sconv_discrete_ppo.yaml
@@ -8,6 +8,7 @@ image_encoder:
     width: ${shared.image_width}
     channels: ${shared.image_channels}
     latent_dim: 512 # From primitive AMI.
+    do_batchnorm: True
 
 image_decoder:
   _target_: ami.models.model_wrapper.ModelWrapper
@@ -19,6 +20,7 @@ image_decoder:
     width: ${models.image_encoder.model.width}
     channels: ${models.image_encoder.model.channels}
     latent_dim: ${models.image_encoder.model.latent_dim}
+    do_batchnorm: True
 
 forward_dynamics:
   _target_: ami.models.model_wrapper.ModelWrapper

--- a/configs/trainers/image_vae/default.yaml
+++ b/configs/trainers/image_vae/default.yaml
@@ -5,6 +5,7 @@ partial_dataloader:
   _partial_: true
   batch_size: 8
   shuffle: true
+  drop_last: true # for batchnorm.
 
 partial_optimizer:
   _target_: torch.optim.Adam

--- a/tests/models/components/test_small_deconv_net.py
+++ b/tests/models/components/test_small_deconv_net.py
@@ -19,15 +19,17 @@ class TestSmallDeconvNet:
             channels,
             dim_in,
             positional_bias,
-            nl""",
+            nl,
+            do_batchnorm
+            """,
         [
-            (8, 256, 256, 3, 256, False, torch.nn.LeakyReLU()),
-            (1, 128, 256, 3, 128, True, torch.nn.LeakyReLU(negative_slope=0.2)),
-            (4, 512, 128, 3, 256, True, torch.nn.LeakyReLU()),
+            (8, 256, 256, 3, 256, False, torch.nn.LeakyReLU(), False),
+            (1, 128, 256, 3, 128, True, torch.nn.LeakyReLU(negative_slope=0.2), True),
+            (4, 512, 128, 3, 256, True, torch.nn.LeakyReLU(), False),
         ],
     )
-    def test_forward(self, batch, height, width, channels, dim_in, positional_bias, nl):
-        mod = cls(height, width, channels, dim_in, positional_bias, nl)
+    def test_forward(self, batch, height, width, channels, dim_in, positional_bias, nl, do_batchnorm):
+        mod = cls(height, width, channels, dim_in, positional_bias, nl, do_batchnorm)
         x = torch.randn(batch, dim_in)
         x = mod.forward(x)
         assert x.size(0) == batch, "batch size mismatch"


### PR DESCRIPTION
## 概要

VAEの学習が不安定であり、予測誤差による報酬が爆発して方策が壊れてしまう(Entropyが0になる)問題があったため、BatchNormを追加し、安定化させた。

結果、安定して動作し続けることが確認された。

![image](https://github.com/MLShukai/ami/assets/59220704/1cf44919-2bcd-41ae-a0cb-fb2bd1db4c07)

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
