### PR TITLE
SioConvのバグを修正

### DIFF
--- a/ami/models/components/sioconv.py
+++ b/ami/models/components/sioconv.py
@@ -91,7 +91,9 @@ class SioConvLayer(nn.Module):
         ones_fft = torch.fft.rfft(ones, n=len * 2)
 
         ln_da = -torch.exp(self.ln_a) * F.softplus(self.fc_dt(x))  # (batch, len, num_head)
-        ln_da_masked = einops.repeat(ln_da, "b l h ->b l m h", m=len).tril(-1)  # (batch, len, len, num_head)
+        ln_da_masked = (
+            einops.repeat(ln_da, "b l h ->b l m h", m=len).permute(0, 3, 1, 2).tril(-1).permute(0, 2, 3, 1)
+        )  # (batch, len, len, num_head)
         ln_da_masked_fft = torch.fft.rfft(ln_da_masked, n=len * 2, dim=1)  # (batch, len, len, num_head)
         ln_da_masked_conv = torch.fft.irfft(torch.einsum("blmh,l->blmh", ln_da_masked_fft, ones_fft), dim=1).narrow(
             1, 0, len

--- a/ami/models/components/sioconv.py
+++ b/ami/models/components/sioconv.py
@@ -96,7 +96,7 @@ class SioConvLayer(nn.Module):
         ln_da_masked_conv = torch.fft.irfft(torch.einsum("blmh,l->blmh", ln_da_masked_fft, ones_fft), dim=1).narrow(
             1, 0, len
         )  # (batch, len, len, num_head)
-        da_masked_conv = torch.exp(ln_da_masked_conv).tril()  # (batch, len, len, num_head)
+        da_masked_conv = torch.exp(ln_da_masked_conv).permute(0,3,1,2).tril().permute(0,2,3,1)  # (batch, len, len, num_head)
 
         h_inner_chunk = torch.einsum("blmh,bmhi->blhi", da_masked_conv, z)
 

--- a/ami/models/components/sioconv.py
+++ b/ami/models/components/sioconv.py
@@ -96,7 +96,9 @@ class SioConvLayer(nn.Module):
         ln_da_masked_conv = torch.fft.irfft(torch.einsum("blmh,l->blmh", ln_da_masked_fft, ones_fft), dim=1).narrow(
             1, 0, len
         )  # (batch, len, len, num_head)
-        da_masked_conv = torch.exp(ln_da_masked_conv).permute(0,3,1,2).tril().permute(0,2,3,1)  # (batch, len, len, num_head)
+        da_masked_conv = (
+            torch.exp(ln_da_masked_conv).permute(0, 3, 1, 2).tril().permute(0, 2, 3, 1)
+        )  # (batch, len, len, num_head)
 
         h_inner_chunk = torch.einsum("blmh,bmhi->blhi", da_masked_conv, z)
 


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
SioConvの計算に致命的なミスがあり、マルチヘッドがシングルヘッドになってまともに推論できない状態になっていました
大変申し訳ございません
発覚が遅れた経緯としては以下のようになります：
1. LLMとしてのSioConvは逐次変更しており、訓練コード周りの整理を行っていた
2. 推論周りの処理の整理を見落とし、参照するパラメータファイルとモデルが古いもののままになっていた
3. まともに推論ができない状態にもかかわらず古いパラメータとモデルであるていど推論できるように見えてしまっていた

今回の修正で直ったと思いますが引き続きLLMの実験を通してこちらでも改善を確認します
訓練に時間がかかるため少しかかります

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
