### PR TITLE
agentのsetup/teardownのapiを破壊的変更

### DIFF
--- a/ami/interactions/agents/base_agent.py
+++ b/ami/interactions/agents/base_agent.py
@@ -74,24 +74,14 @@ class BaseAgent(ABC, Generic[ObsType, ActType], SaveAndLoadStateMixin, PauseResu
         """
         raise NotImplementedError
 
-    def setup(self, observation: ObsType) -> ActType | None:
+    def setup(self) -> None:
         """Setup procedure for the Agent.
 
-        Args:
-            observation: Initial observation from the environment.
-
-        Returns:
-            action: Initial action to be taken in response to the environment during interaction. Returning no action is also an option.
+        Called before first `step`.
         """
-        return None
 
-    def teardown(self, observation: ObsType) -> ActType | None:
+    def teardown(self) -> None:
         """Teardown procedure for the Agent.
 
-        Args:
-            observation: Final observation from the environment.
-
-        Returns:
-            action: Final action to be taken in the interaction. Returning no action is also an option.
+        Called after final `step`.
         """
-        return None

--- a/ami/interactions/agents/curiosity_image_ppo_agent.py
+++ b/ami/interactions/agents/curiosity_image_ppo_agent.py
@@ -129,15 +129,15 @@ class CuriosityImagePPOAgent(BaseAgent[Tensor, Tensor]):
 
         return action
 
-    def setup(self, observation: Tensor) -> Tensor:
-        super().setup(observation)
-
+    def setup(self) -> None:
+        super().setup()
         self.step_data = StepData()
-
-        return self._common_step(observation, initial_step=True)
+        self.initial_step = True
 
     def step(self, observation: Tensor) -> Tensor:
-        return self._common_step(observation, initial_step=False)
+        action = self._common_step(observation, initial_step=self.initial_step)
+        self.initial_step = False
+        return action
 
     @override
     def save_state(self, path: Path) -> None:
@@ -238,15 +238,16 @@ class CuriosityImageSeparatePolicyValueAgent(BaseAgent[Tensor, Tensor]):
 
         return action
 
-    def setup(self, observation: Tensor) -> Tensor:
-        super().setup(observation)
+    def setup(self) -> None:
+        super().setup()
 
         self.step_data = StepData()
-
-        return self._common_step(observation, initial_step=True)
+        self.initial_step = True
 
     def step(self, observation: Tensor) -> Tensor:
-        return self._common_step(observation, initial_step=False)
+        action = self._common_step(observation, initial_step=self.initial_step)
+        self.initial_step = False
+        return action
 
     @override
     def save_state(self, path: Path) -> None:

--- a/ami/interactions/agents/discrete_random_action_agent.py
+++ b/ami/interactions/agents/discrete_random_action_agent.py
@@ -38,7 +38,7 @@ class DiscreteRandomActionAgent(BaseAgent[Any, Tensor]):
         return len(self.action_choices_per_category)
 
     @override
-    def setup(self, observation: Any) -> Tensor | None:
+    def setup(self) -> None:
         self.remaining_action_repeat_counts = [0] * self.num_actions
         self.action = [0] * self.num_actions
         return None

--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -210,8 +210,8 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
 
         return action
 
-    def setup(self, observation: Tensor) -> Tensor:
-        super().setup(observation)
+    def setup(self) -> None:
+        super().setup()
         self.step_data = StepData()
 
         device = self.exact_forward_dynamics_hidden_state.device
@@ -219,10 +219,12 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
         self.forward_dynamics_hidden_state_imaginations = torch.empty(0, device=device, dtype=dtype)
         self.predicted_embed_obs_imaginations = torch.empty(0, device=device)
 
-        return self._common_step(observation, initial_step=True)
+        self.initial_step = True
 
     def step(self, observation: Tensor) -> Tensor:
-        return self._common_step(observation, initial_step=False)
+        action = self._common_step(observation, initial_step=self.initial_step)
+        self.initial_step = False
+        return action
 
     @override
     def save_state(self, path: Path) -> None:

--- a/ami/interactions/interaction.py
+++ b/ami/interactions/interaction.py
@@ -50,10 +50,7 @@ class Interaction(SaveAndLoadStateMixin, PauseResumeEventMixin):
             action_wrapper.setup()
 
         self.environment.setup()
-        initial_obs = self.environment.observe()
-        initial_action = self.agent.setup(self.wrap_observation(initial_obs))
-        if initial_action is not None:
-            self.environment.affect(self.wrap_action(initial_action))
+        self.agent.setup()
 
     def step(self) -> None:
         """Executes a single step of interaction.
@@ -66,10 +63,7 @@ class Interaction(SaveAndLoadStateMixin, PauseResumeEventMixin):
 
     def teardown(self) -> None:
         """Called at the end of the interaction."""
-        final_obs = self.environment.observe()
-        final_action = self.agent.teardown(self.wrap_observation(final_obs))
-        if final_action is not None:
-            self.environment.affect(self.wrap_action(final_action))
+        self.agent.teardown()
         self.environment.teardown()
 
         for observation_wrapper in self.observation_wrappers:

--- a/tests/interactions/agents/test_curiosity_image_ppo_agent.py
+++ b/tests/interactions/agents/test_curiosity_image_ppo_agent.py
@@ -122,12 +122,12 @@ class TestCuriosityImagePPOAgent:
     def test_setup_step_teardown(self, agent: CuriosityImagePPOAgent):
 
         observation = torch.randn(CHANNELS, HEIGHT, WIDTH)
-        action = agent.setup(observation)
-
-        assert action.shape == (len(ACTION_CHOICES_PER_CATEGORY),)
+        agent.setup()
+        assert agent.initial_step
 
         for _ in range(10):
             action = agent.step(observation)
+            assert not agent.initial_step
             assert action.shape == (len(ACTION_CHOICES_PER_CATEGORY),)
 
         assert agent.step_data[DataKeys.OBSERVATION].shape == observation.shape
@@ -221,12 +221,12 @@ class TestCuriosityImageSeparatePolicyValueAgent:
 
     def test_setup_step_teardown(self, agent: CuriosityImageSeparatePolicyValueAgent):
         observation = torch.randn(CHANNELS, HEIGHT, WIDTH)
-        action = agent.setup(observation)
-
-        assert action.shape == (ACTION_DIM,)
+        agent.setup()
+        assert agent.initial_step
 
         for _ in range(10):
             action = agent.step(observation)
+            assert not agent.initial_step
             assert action.shape == (ACTION_DIM,)
 
         assert agent.step_data[DataKeys.OBSERVATION].shape == observation.shape

--- a/tests/interactions/agents/test_disrete_random_action_agent.py
+++ b/tests/interactions/agents/test_disrete_random_action_agent.py
@@ -19,21 +19,21 @@ class TestDiscreteRandomActionAgent:
         assert agent.max_action_repeat == 3
 
     def test_setup(self, agent):
-        agent.setup(None)
+        agent.setup()
         assert len(agent.remaining_action_repeat_counts) == 3
         assert len(agent.action) == 3
         assert all(count == 0 for count in agent.remaining_action_repeat_counts)
         assert all(action == 0 for action in agent.action)
 
     def test_step_output_shape(self, agent):
-        agent.setup(None)
+        agent.setup()
         action = agent.step(None)
         assert isinstance(action, torch.Tensor)
         assert action.shape == (3,)
         assert action.dtype == torch.long
 
     def test_action_choices(self, agent):
-        agent.setup(None)
+        agent.setup()
         for _ in range(100):  # Run multiple times to increase chance of covering all possibilities
             action = agent.step(None)
             assert 0 <= action[0] < 3

--- a/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
+++ b/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
@@ -104,12 +104,12 @@ class TestMultiStepImaginationCuriosityImageAgent:
 
     def test_setup_step_teardown(self, agent: MultiStepImaginationCuriosityImageAgent):
         observation = torch.randn(CHANNELS, HEIGHT, WIDTH)
-        action = agent.setup(observation)
+        action = agent.setup()
 
-        assert action.shape == (ACTION_DIM,)
-
+        assert agent.initial_step
         for _ in range(10):
             action = agent.step(observation)
+            assert not agent.initial_step
             assert action.shape == (ACTION_DIM,)
             assert agent.global_step == agent.logger.global_step
 

--- a/tests/interactions/test_interaction.py
+++ b/tests/interactions/test_interaction.py
@@ -35,8 +35,7 @@ class TestInteraction:
         mock_obs_wrapper.setup.assert_called_once()
         mock_act_wrapper.setup.assert_called_once()
         mock_env.setup.assert_called_once()
-        mock_agent.setup.assert_called_once_with("wrapped_obs(observation)")
-        mock_env.affect.assert_called_once_with("wrapped_act(setup_action)")
+        mock_agent.setup.assert_called_once()
 
     def test_step(self, interaction, mock_env, mock_agent):
         interaction.step()
@@ -47,8 +46,7 @@ class TestInteraction:
     def test_teardown(self, interaction, mock_env, mock_agent, mock_obs_wrapper, mock_act_wrapper):
         interaction.teardown()
 
-        mock_agent.teardown.assert_called_once_with("wrapped_obs(observation)")
-        mock_env.affect.assert_called_once_with("wrapped_act(teardown_action)")
+        mock_agent.teardown.assert_called_once()
         mock_env.teardown.assert_called_once()
         mock_obs_wrapper.teardown.assert_called_once()
         mock_act_wrapper.teardown.assert_called_once()


### PR DESCRIPTION
## 概要

#226 Agentの内部に子Agentを持つ設計にする関係上、setupとteardownメソッドがactionを返す仕様を維持することが難しいため破壊的な変更を行いました。

## 変更内容

setup, teardownメソッドの引数と戻り値を無くしました。

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
