### PR TITLE
ami.timeに状態保存/読込機能を追加

### DIFF
--- a/ami/time.py
+++ b/ami/time.py
@@ -195,7 +195,7 @@ class TimeController:
         """Return the time controller state.
 
         Returns:
-            TimeControllerState: dict of state values.
+            TimeControllerState: State information that can reproduce the current time flow progression of the system.
         """
         self._update_scaled_anchor_values()
         return self.TimeControllerState(
@@ -207,6 +207,8 @@ class TimeController:
     @with_lock
     def load_state_dict(self, state_dict: TimeControllerState) -> None:
         """Loads states.
+
+        When a state is loaded, the system time starts from the time the state was retrieved.
 
         Args:
             state_dict (TimeControllerState): The dict which contains state values.

--- a/ami/time.py
+++ b/ami/time.py
@@ -197,6 +197,7 @@ class TimeController:
         Returns:
             TimeControllerState: dict of state values.
         """
+        self._update_scaled_anchor_values()
         return self.TimeControllerState(
             scaled_anchor_time=self._scaled_anchor_time,
             scaled_anchor_monotonic=self._scaled_anchor_monotonic,
@@ -213,6 +214,7 @@ class TimeController:
         self._scaled_anchor_time = state_dict["scaled_anchor_time"]
         self._scaled_anchor_monotonic = state_dict["scaled_anchor_monotonic"]
         self._scaled_anchor_perf_counter = state_dict["scaled_anchor_perf_counter"]
+        self._update_anchor_values()
 
 
 # Create a global instance of TimeController


### PR DESCRIPTION
## 概要

システムの再開機能を実現するためにami time モジュールにstate_dict, load_state_dictを実装しました。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
