### PR TITLE
ami.timeに置換

### DIFF
--- a/ami/checkpointing/checkpoint_schedulers.py
+++ b/ami/checkpointing/checkpoint_schedulers.py
@@ -1,7 +1,8 @@
-import time
 from abc import ABC, abstractmethod
 
 from typing_extensions import override
+
+from ami import time
 
 from .checkpointing import Checkpointing
 

--- a/ami/interactions/interval_adjustors.py
+++ b/ami/interactions/interval_adjustors.py
@@ -1,6 +1,7 @@
 import math
-import time
 from abc import ABC, abstractmethod
+
+from ami import time
 
 
 class BaseIntervalAdjustor(ABC):

--- a/ami/tensorboard_loggers.py
+++ b/ami/tensorboard_loggers.py
@@ -1,5 +1,4 @@
 import math
-import time
 from collections import ChainMap
 from collections.abc import Mapping, MutableSequence
 from typing import Any, TypeAlias
@@ -7,6 +6,8 @@ from typing import Any, TypeAlias
 from torch import Tensor
 from torch.utils.tensorboard import SummaryWriter
 from typing_extensions import override
+
+from ami import time
 
 LoggableTypes: TypeAlias = Tensor | float | int | bool | str
 

--- a/ami/threads/main_thread.py
+++ b/ami/threads/main_thread.py
@@ -69,7 +69,9 @@ class MainThread(BaseThread):
 
     def worker(self) -> None:
         self.logger.info("Start main thread.")
-        self.logger.info(f"Maxmum uptime is set to {self._max_uptime}.")
+        self.logger.info(
+            f"Maxmum uptime is set to {self._max_uptime:.1f} [secs]. (actually {self._max_uptime / time.get_time_scale():.1f} [secs] in time scale x{time.get_time_scale()})"
+        )
         self.thread_controller.activate()
         start_time = time.time()
 

--- a/ami/threads/main_thread.py
+++ b/ami/threads/main_thread.py
@@ -52,6 +52,8 @@ class MainThread(BaseThread):
         self._host = address[0]
         self._port = address[1]
         self.thread_controller = ThreadController()
+        self.thread_controller.on_paused = self.on_paused
+        self.thread_controller.on_resumed = self.on_resumed
         self.web_api_handler = WebApiHandler(ThreadControllerStatus(self.thread_controller), self._host, self._port)
         self._timeout_for_all_threads_pause = timeout_for_all_threads_pause
         self._max_attempts_to_pause_all_threads = max_attempts_to_pause_all_threads
@@ -110,11 +112,9 @@ class MainThread(BaseThread):
                 case ControlCommands.PAUSE:
                     self.logger.info("Pausing...")
                     self.thread_controller.pause()
-                    self.on_paused()
                 case ControlCommands.RESUME:
                     self.logger.info("Resuming...")
                     self.thread_controller.resume()
-                    self.on_resumed()
                 case ControlCommands.SHUTDOWN:
                     self.logger.info("Shutting down...")
                     self.thread_controller.shutdown()

--- a/ami/threads/thread_control.py
+++ b/ami/threads/thread_control.py
@@ -40,11 +40,17 @@ class ThreadController:
     NOTE: **Only one thread can control this object.**
     """
 
+    # 外部から定義されるコールバック関数
+    on_paused: OnPausedCallbackType
+    on_resumed: OnResumedCallbackType
+
     def __init__(self) -> None:
         """Construct this class."""
         self._shutdown_event = threading.Event()
         self._resume_event = threading.Event()  # For pause and resume.
         self._logger = get_main_thread_logger(self.__class__.__name__)
+        self.on_paused = dummy_on_paused
+        self.on_resumed = dummy_on_resumed
 
         # Thread間でHandlerインスタンスを分離。
         self.handlers: dict[ThreadTypes, ThreadCommandHandler] = dict()
@@ -70,10 +76,12 @@ class ThreadController:
     def resume(self) -> None:
         """Sets the resume flag."""
         self._resume_event.set()
+        self.on_resumed()
 
     def pause(self) -> None:
         """Clears the resume flag."""
         self._resume_event.clear()
+        self.on_paused()
 
     def is_resumed(self) -> bool:
         """Returns the resume flag."""

--- a/ami/time.py
+++ b/ami/time.py
@@ -75,6 +75,11 @@ class TimeController:
         self._is_paused = False
 
     @with_lock
+    def is_paused(self) -> bool:
+        """Public interface for checking pause."""
+        return self._is_paused
+
+    @with_lock
     def _update_anchor_values(self) -> None:
         self._anchor_time = _original_time.time()
         self._anchor_perf_counter = _original_time.perf_counter()
@@ -219,6 +224,7 @@ class TimeController:
 _time_controller = TimeController()
 
 # Expose the public methods
+is_paused = _time_controller.is_paused
 sleep = _time_controller.sleep
 time = _time_controller.time
 perf_counter = _time_controller.perf_counter

--- a/configs/interaction/default.yaml
+++ b/configs/interaction/default.yaml
@@ -7,4 +7,4 @@ defaults:
 
 interval_adjustor:
   _target_: ami.interactions.interval_adjustors.SleepIntervalAdjustor
-  interval: ${python.eval:"0.1 / ${time_scale}"} # 100 ms, 10 Hz.
+  interval: 0.1 # 100 ms, 10 Hz.

--- a/configs/threads/default.yaml
+++ b/configs/threads/default.yaml
@@ -1,7 +1,7 @@
 main_thread:
   _target_: ami.threads.main_thread.MainThread
   address: ["0.0.0.0", 8391]
-  max_uptime: ${python.eval:"float('${max_uptime}') / ${time_scale}"}
+  max_uptime: ${python.eval:"float('${max_uptime}')"}
 
 inference_thread:
   _target_: ami.threads.inference_thread.InferenceThread

--- a/scripts/launch.py
+++ b/scripts/launch.py
@@ -7,6 +7,7 @@ import rootutils
 import torch
 from omegaconf import DictConfig, open_dict
 
+import ami.time
 from ami.checkpointing.checkpoint_schedulers import BaseCheckpointScheduler
 from ami.checkpointing.checkpointing import Checkpointing
 from ami.data.utils import DataCollectorsDict
@@ -43,6 +44,10 @@ register_custom_resolvers()
 @hydra.main(config_path="../configs", config_name="launch", version_base="1.3")
 def main(cfg: DictConfig) -> None:
     logger.info("Launch AMI.")
+
+    ami.time.set_time_scale(cfg.time_scale)
+    logger.info(f"Set time scale to {ami.time.get_time_scale()}")
+
     if precision := cfg.get("torch_float32_matmul_precision"):
         torch.set_float32_matmul_precision(precision)
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -9,6 +9,7 @@ from tests.helpers import skip_if_platform_is_not_linux
 
 def test_module_global_values():
     controller = ami_time._time_controller
+    assert ami_time.is_paused == controller.is_paused
     assert ami_time.sleep == controller.sleep
     assert ami_time.time == controller.time
     assert ami_time.monotonic == controller.monotonic
@@ -277,3 +278,11 @@ def test_state_dict_consistency():
         func = getattr(controller, name)
         new_func = getattr(new_controller, name)
         assert func() == pytest.approx(new_func(), abs=1e-4), f"'{name}' is not consistent."
+
+
+def test_is_paused(controller):
+    assert not controller.is_paused()
+    controller.pause()
+    assert controller.is_paused()
+    controller.resume()
+    assert not controller.is_paused()

--- a/tests/threads/test_main_thread.py
+++ b/tests/threads/test_main_thread.py
@@ -1,3 +1,7 @@
+import random
+from pathlib import Path
+
+import ami.time
 from ami.threads.main_thread import MainThread, ThreadTypes
 from ami.threads.shared_object_names import SharedObjectNames
 
@@ -8,3 +12,29 @@ class TestMainThread:
 
         # test can get.
         SharedObjectNames.THREAD_COMMAND_HANDLERS in mt.shared_objects_from_this_thread
+
+    def test_pause_resume_event_callback(self, thread_objects):
+        mt: MainThread = thread_objects[0]
+        assert not ami.time.is_paused()
+        mt.on_paused()
+        assert ami.time.is_paused()
+        mt.on_resumed()
+        assert not ami.time.is_paused()
+
+    def test_save_and_load_state(self, thread_objects, tmp_path: Path):
+        path = tmp_path / "main"
+        mt: MainThread = thread_objects[0]
+        state = ami.time.state_dict()
+        mt.save_state(path)
+        assert path.is_dir()
+        assert (path / "time_state.pkl").is_file()
+        ami.time.load_state_dict(
+            ami.time.TimeController.TimeControllerState(
+                scaled_anchor_monotonic=random.random(),
+                scaled_anchor_perf_counter=random.random(),
+                scaled_anchor_time=random.random(),
+            )
+        )
+        assert ami.time.state_dict() != state
+        mt.load_state(path)
+        assert ami.time.state_dict() == state

--- a/tests/threads/test_main_thread.py
+++ b/tests/threads/test_main_thread.py
@@ -1,6 +1,8 @@
 import random
 from pathlib import Path
 
+import pytest
+
 import ami.time
 from ami.threads.main_thread import MainThread, ThreadTypes
 from ami.threads.shared_object_names import SharedObjectNames
@@ -35,6 +37,11 @@ class TestMainThread:
                 scaled_anchor_time=random.random(),
             )
         )
-        assert ami.time.state_dict() != state
+        loaded_state = ami.time.state_dict()
+        for key in loaded_state.keys():
+            assert state[key] != pytest.approx(loaded_state[key], abs=0.1)
+
         mt.load_state(path)
-        assert ami.time.state_dict() == state
+        loaded_state = ami.time.state_dict()
+        for key in loaded_state.keys():
+            assert state[key] == pytest.approx(loaded_state[key], abs=0.1)


### PR DESCRIPTION
## 概要

#227 timeモジュールを使用している全ての箇所を置換しようかとも思いましたが、割と時間のスケールが必要ない箇所が多かったので一旦本当に必要な箇所だけ置換しました。

## 変更内容

* checkpoint_scheduler: チェックポイントのタイミングはAMIの学習の進み方に対していつも一定であってほしいため、時間スケールを有効化
* interval adjustor: 時間スケールで1ステップあたりのインターバルを変化させたいため有効化
* main thread: システムの最大起動時間 (amiのlife time) をスケールさせたいため、有効化

状態情報の保存と読込、pause/resumeのイベント呼び出しコールバックの整備を行いました。

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
