### PR TITLE
複数のAgentからDataCollectorのcollectが呼ばれないよう排他制御

### DIFF
--- a/ami/data/utils.py
+++ b/ami/data/utils.py
@@ -49,10 +49,52 @@ class DataUsersDict(UserDict[str, ThreadSafeDataUser[Any]], SaveAndLoadStateMixi
 
 class DataCollectorsDict(UserDict[str, ThreadSafeDataCollector[Any]]):
     """A class for aggregating `DataCollectors` to invoke their `collect`
-    methods within the agent class."""
+    methods within the agent class.
+
+    Once a collector is acquired, it cannot be released until system
+    restart. Acquired collectors are excluded from the collect
+    operation.
+    """
+
+    def __init__(self, *args: Any, **kwds: Any) -> None:
+        super().__init__(*args, **kwds)
+        self._acquired_collectors: set[str] = set()
+
+    def acquire(self, collector_name: str) -> ThreadSafeDataCollector[Any]:
+        """Acquire permanent exclusive access to a specific data collector.
+
+        Once acquired, a collector cannot be released until system restart.
+
+        Args:
+            collector_name: Name of the collector to acquire
+
+        Returns:
+            ThreadSafeDataCollector[Any]: The acquired data collector
+
+        Raises:
+            KeyError: If collector_name is already acquired or doesn't exist
+        """
+        if collector_name in self._acquired_collectors:
+            raise KeyError(f"Data collector '{collector_name}' is already acquired.")
+        if collector_name not in self:
+            raise KeyError(f"Data collector '{collector_name}' not found.")
+
+        self._acquired_collectors.add(collector_name)
+        return self[collector_name]
 
     def collect(self, step_data: StepData) -> None:
-        """Calls the `collect` method on every `DataCollector` item."""
+        """Calls the `collect` method on every non-acquired `DataCollector`
+        item.
+
+        Args:
+            step_data: Data to be collected
+
+        Raises:
+            RuntimeError: If any collectors are currently acquired
+        """
+        if self._acquired_collectors:
+            acquired_list = ", ".join(sorted(self._acquired_collectors))
+            raise RuntimeError(f"Cannot collect while collectors are acquired: {acquired_list}")
         for v in self.values():
             v.collect(step_data)
 

--- a/ami/data/utils.py
+++ b/ami/data/utils.py
@@ -92,7 +92,7 @@ class DataCollectorsDict(UserDict[str, ThreadSafeDataCollector[Any]]):
         Raises:
             RuntimeError: If any collectors are currently acquired
         """
-        if self._acquired_collectors:
+        if len(self._acquired_collectors) > 0:
             acquired_list = ", ".join(sorted(self._acquired_collectors))
             raise RuntimeError(f"Cannot collect while collectors are acquired: {acquired_list}")
         for v in self.values():

--- a/ami/interactions/agents/base_agent.py
+++ b/ami/interactions/agents/base_agent.py
@@ -78,7 +78,7 @@ class BaseAgent(ABC, Generic[ObsType, ActType], SaveAndLoadStateMixin, PauseResu
     def get_data_collector(self, name: str) -> ThreadSafeDataCollector[Any]:
         if name not in self.data_collectors:
             raise KeyError(f"The specified data collector name '{name}' does not exist.")
-        return self.data_collectors[name]
+        return self.data_collectors.acquire(name)
 
     @abstractmethod
     def step(self, observation: ObsType) -> ActType:

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -54,3 +54,27 @@ class TestDataCollectorsAndUsersDict:
 
         for user in users_dict.values():
             assert len(user.buffer.obs) == 1
+
+    def test_acquire(self, collectors_dict: DataCollectorsDict) -> None:
+        """Test acquiring a collector."""
+        # Test successful acquire
+        collector = collectors_dict.acquire("a")
+        assert isinstance(collector, ThreadSafeDataCollector)
+        assert "a" in collectors_dict._acquired_collectors
+
+    def test_acquire_non_existent(self, collectors_dict: DataCollectorsDict) -> None:
+        """Test acquiring a non-existent collector."""
+        with pytest.raises(KeyError, match="Data collector 'non_existent' not found"):
+            collectors_dict.acquire("non_existent")
+
+    def test_acquire_already_acquired(self, collectors_dict: DataCollectorsDict) -> None:
+        """Test acquiring an already acquired collector."""
+        collectors_dict.acquire("a")
+        with pytest.raises(KeyError, match="Data collector 'a' is already acquired"):
+            collectors_dict.acquire("a")
+
+    def test_collect_with_acquired(self, collectors_dict: DataCollectorsDict, step_data: StepData) -> None:
+        """Test collect operation when collectors are acquired."""
+        collectors_dict.acquire("a")
+        with pytest.raises(RuntimeError, match="Cannot collect while collectors are acquired"):
+            collectors_dict.collect(step_data)

--- a/tests/interactions/agents/test_base_agent.py
+++ b/tests/interactions/agents/test_base_agent.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest_mock import MockerFixture
 
 from ami.interactions.agents.base_agent import BaseAgent
@@ -20,6 +21,10 @@ class TestBaseAgent:
         agent.attach_data_collectors(data_collectors_dict)
 
         assert agent.data_collector1
+
+        # check acquiring
+        with pytest.raises(RuntimeError):
+            data_collectors_dict.collect(...)
 
     def test_child_agent_method_call(self, mocker: MockerFixture, inference_wrappers_dict, data_collectors_dict):
         mock_agent = mocker.Mock(BaseAgent)


### PR DESCRIPTION
## 変更内容

#226 を実装した関係上、複数のAgentからDataCollectorを呼び出せるようになってしまいました。同じDataCollectorが同一時刻に複数`collect`を呼ばれてしまうとデータの並び順など不整合が発生してしまう恐れがあります。

`acquire` methodで明示的に占有することによってそのリスクを未然に防ぎます。

ただし、後方互換性のために`DataCollectorsDict.collect`メソッドは残したままなので、それを複数のAgentから呼ばれるリスクはあります。
今後開発する`pamiq-core`には``DataCollectorsDict.collect`は実装しない予定です。


## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
