### PR TITLE
単一のCuriosityAgentを実装

### DIFF
--- a/ami/interactions/agents/curiosity_agent.py
+++ b/ami/interactions/agents/curiosity_agent.py
@@ -18,6 +18,15 @@ from .base_agent import BaseAgent
 
 
 class CuriosityAgent(BaseAgent[Tensor, Tensor]):
+    """A reinforcement learning agent that uses curiosity-driven exploration
+    through forward dynamics prediction.
+
+    This agent implements curiosity-driven exploration by predicting
+    future observations and using prediction errors as intrinsic
+    rewards. It maintains a forward dynamics model to predict future
+    states and a policy-value network for action selection.
+    """
+
     @override
     def __init__(
         self,
@@ -26,6 +35,15 @@ class CuriosityAgent(BaseAgent[Tensor, Tensor]):
         max_imagination_steps: int = 1,
         reward_average_method: Callable[[Tensor], Tensor] = torch.mean,
     ) -> None:
+        """Initializes the CuriosityAgent.
+
+        Args:
+            initial_hidden (Tensor): Initial hidden state tensor for the forward dynamics model.
+            logger (TimeIntervalLogger): Logger instance for recording metrics and rewards.
+            max_imagination_steps (int, optional): Maximum number of steps to imagine into the future. Must be >= 1. Defaults to 1.
+            reward_average_method (Callable[[Tensor], Tensor], optional): Function to average rewards across imagination steps.
+                Takes a tensor of rewards (imagination_steps,) and returns a scalar reward. Defaults to torch.mean.
+        """
         super().__init__()
         if max_imagination_steps < 1:
             raise ValueError(...)
@@ -78,6 +96,16 @@ class CuriosityAgent(BaseAgent[Tensor, Tensor]):
         return action
 
     def _common_step(self, observation: Tensor, initial_step: bool) -> Tensor:
+        """Executes the common step procedure for the curiosity-driven agent.
+
+        Args:
+            observation (Tensor): Current observation from the environment
+            initial_step (bool): Whether this is the first step in an episode.
+                When True, skips reward calculation as there are no previous predictions.
+
+        Returns:
+            Tensor: Selected action to be executed in the environment
+        """
         if not initial_step:
             observation = observation.type_as(observation)
             target_obses = observation.expand_as(self.obs_imaginations)

--- a/ami/interactions/agents/curiosity_agent.py
+++ b/ami/interactions/agents/curiosity_agent.py
@@ -92,7 +92,7 @@ class CuriosityAgent(BaseAgent[Tensor, Tensor]):
     def setup(self) -> None:
         super().setup()
         self.step_data = StepData()
-        self.forward_dynamics_hidden_imaginations = torch.empty(0).type_as(self.forward_dynamics_hidden_imaginations)
+        self.forward_dynamics_hidden_imaginations = torch.empty(0).type_as(self.head_forward_dynamics_hidden_state)
         self.obs_imaginations = torch.empty(0, device=self.forward_dynamics_hidden_imaginations.device)
         self.initial_step = True
 
@@ -134,8 +134,6 @@ class CuriosityAgent(BaseAgent[Tensor, Tensor]):
             : self.max_imagination_steps
         ]  # (imaginations, depth, dim)
 
-        action_dist: Distribution
-        value: Tensor
         action_dist: Distribution
         value: Tensor
         action_dist, value = self.policy_value(obs_imaginations[0], hidden_imaginations[0])

--- a/ami/interactions/agents/curiosity_agent.py
+++ b/ami/interactions/agents/curiosity_agent.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+from typing import Callable
+
+import torch
+from torch import Tensor
+from torch.distributions import Distribution
+from typing_extensions import override
+
+from ami.data.buffers.buffer_names import BufferNames
+from ami.data.step_data import DataKeys, StepData
+from ami.models.forward_dynamics import ForwardDynamcisWithActionReward
+from ami.models.model_names import ModelNames
+from ami.models.model_wrapper import ThreadSafeInferenceWrapper
+from ami.models.policy_value_common_net import PolicyValueCommonNet
+from ami.tensorboard_loggers import TimeIntervalLogger
+
+from .base_agent import BaseAgent
+
+
+class CuriosityAgent(BaseAgent[Tensor, Tensor]):
+    @override
+    def __init__(
+        self,
+        initial_hidden: Tensor,
+        logger: TimeIntervalLogger,
+        max_imagination_steps: int = 1,
+        reward_average_method: Callable[[Tensor], Tensor] = torch.mean,
+    ) -> None:
+        super().__init__()
+        if max_imagination_steps < 1:
+            raise ValueError(...)
+
+        self.head_forward_dynamics_hidden_state = initial_hidden
+        self.logger = logger
+        self.max_imagination_steps = max_imagination_steps
+        self.reward_average_method = reward_average_method
+
+    @override
+    def on_inference_models_attached(self) -> None:
+        super().on_inference_models_attached()
+        self.forward_dynamics: ThreadSafeInferenceWrapper[ForwardDynamcisWithActionReward] = self.get_inference_model(
+            ModelNames.FORWARD_DYNAMICS
+        )
+        self.policy_value: ThreadSafeInferenceWrapper[PolicyValueCommonNet] = self.get_inference_model(
+            ModelNames.POLICY_VALUE
+        )
+
+    @override
+    def on_data_collectors_attached(self) -> None:
+        super().on_data_collectors_attached()
+        self.forward_dynamics_collector = self.get_data_collector(
+            BufferNames.FORWARD_DYNAMICS_TRAJECTORY,
+        )
+        self.policy_collector = self.get_data_collector(
+            BufferNames.PPO_TRAJECTORY,
+        )
+
+    # ###### INTERACTION PROCESS ########
+
+    head_forward_dynamics_hidden_state: Tensor  # (depth, dim)
+    obs_dist_imaginations: Distribution  # (imaginations, dim)
+    obs_imaginations: Tensor  # (imaginations, dim)
+    forward_dynamics_hidden_imaginations: Tensor  # (imaginations, depth, dim)
+    step_data: StepData
+
+    @override
+    def setup(self) -> None:
+        super().setup()
+        self.step_data = StepData()
+        self.forward_dynamics_hidden_imaginations = torch.empty(0).type_as(self.forward_dynamics_hidden_imaginations)
+        self.obs_imaginations = torch.empty(0, device=self.forward_dynamics_hidden_imaginations.device)
+        self.initial_step = True
+
+    @override
+    def step(self, observation: Tensor) -> Tensor:
+        action = self._common_step(observation, self.initial_step)
+        self.initial_step = False
+        return action
+
+    def _common_step(self, observation: Tensor, initial_step: bool) -> Tensor:
+        if not initial_step:
+            observation = observation.type_as(observation)
+            target_obses = observation.expand_as(self.obs_imaginations)
+            reward_imaginations = -self.obs_dist_imaginations.log_prob(target_obses)
+
+            reward = self.reward_average_method(reward_imaginations)
+            self.logger.log("curiosity_agent/reward", reward)
+
+            self.step_data[DataKeys.REWARD] = reward
+            self.forward_dynamics_collector.collect(self.step_data)
+            self.policy_collector.collect(self.step_data)
+
+        obs_imaginations = torch.cat([observation[None], self.obs_imaginations])[
+            : self.max_imagination_steps
+        ]  # (imaginations, dim)
+        hidden_imaginations = torch.cat(
+            [self.head_forward_dynamics_hidden_state[None], self.forward_dynamics_hidden_imaginations]
+        )[
+            : self.max_imagination_steps
+        ]  # (imaginations, depth, dim)
+
+        action_dist: Distribution
+        value: Tensor
+        action_dist: Distribution
+        value: Tensor
+        action_dist, value = self.policy_value(obs_imaginations[0], hidden_imaginations[0])
+        action = action_dist.sample()
+        action_log_prob = action_dist.log_prob(action)
+
+        obs_dist_imaginations, _, _, hidden_imaginations = self.forward_dynamics(
+            obs_imaginations, hidden_imaginations, action.expand((len(obs_imaginations), *action.shape))
+        )
+        obs_imaginations = obs_dist_imaginations.sample()
+
+        self.step_data[DataKeys.OBSERVATION] = observation.cpu()
+        self.step_data[DataKeys.ACTION] = action
+        self.step_data[DataKeys.ACTION_LOG_PROBABILITY] = action_log_prob
+        self.step_data[DataKeys.VALUE] = value
+        self.step_data[DataKeys.HIDDEN] = self.head_forward_dynamics_hidden_state
+        self.logger.log("curiosity_agent/value", value)
+
+        self.obs_dist_imaginations = obs_dist_imaginations
+        self.obs_imaginations = obs_imaginations
+        self.forward_dynamics_hidden_imaginations = hidden_imaginations
+        self.head_forward_dynamics_hidden_state = hidden_imaginations[0]
+
+        self.logger.update()
+        return action
+
+    # ###### State saving ######
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.head_forward_dynamics_hidden_state, path / "head_forward_dynamics_hidden_state.pt")
+
+    @override
+    def load_state(self, path: Path) -> None:
+        self.head_forward_dynamics_hidden_state = torch.load(
+            path / "head_forward_dynamics_hidden_state.pt",
+            map_location=self.head_forward_dynamics_hidden_state.device,
+        )

--- a/ami/interactions/agents/curiosity_agent.py
+++ b/ami/interactions/agents/curiosity_agent.py
@@ -114,7 +114,7 @@ class CuriosityAgent(BaseAgent[Tensor, Tensor]):
             Tensor: Selected action to be executed in the environment
         """
         if not initial_step:
-            observation = observation.type_as(observation)
+            observation = observation.type_as(self.obs_imaginations)
             target_obses = observation.expand_as(self.obs_imaginations)
             reward_imaginations = -self.obs_dist_imaginations.log_prob(target_obses)
 

--- a/tests/interactions/agents/test_curiosity_agent.py
+++ b/tests/interactions/agents/test_curiosity_agent.py
@@ -1,0 +1,179 @@
+import pytest
+import torch
+import torch.nn as nn
+from torch.distributions import Distribution
+
+from ami.data.buffers.buffer_names import BufferNames
+from ami.data.buffers.random_data_buffer import RandomDataBuffer
+from ami.data.step_data import DataKeys
+from ami.data.utils import DataCollectorsDict
+from ami.interactions.agents.curiosity_agent import CuriosityAgent
+from ami.models.components.fully_connected_normal import FullyConnectedNormal
+from ami.models.components.fully_connected_value_head import FullyConnectedValueHead
+from ami.models.components.sioconv import SioConv
+from ami.models.forward_dynamics import ForwardDynamcisWithActionReward
+from ami.models.model_names import ModelNames
+from ami.models.policy_or_value_network import PolicyOrValueNetwork
+from ami.models.policy_value_common_net import PolicyValueCommonNet, SelectObservation
+from ami.models.utils import InferenceWrappersDict, ModelWrapper, ModelWrappersDict
+from ami.tensorboard_loggers import TimeIntervalLogger
+
+# Test constants
+OBSERVATION_DIM = 64
+ACTION_DIM = 8
+HIDDEN_DIM = 64
+DEPTH = 2
+HEAD = 4
+
+
+class TestCuriosityAgent:
+    @pytest.fixture
+    def models(self, device) -> ModelWrappersDict:
+        # Create forward dynamics model
+        forward_dynamics = ForwardDynamcisWithActionReward(
+            nn.Identity(),
+            nn.Identity(),
+            nn.Linear(OBSERVATION_DIM + ACTION_DIM, HIDDEN_DIM),
+            SioConv(DEPTH, HIDDEN_DIM, HEAD, HIDDEN_DIM, 0.1, 16),
+            FullyConnectedNormal(HIDDEN_DIM, OBSERVATION_DIM),
+            FullyConnectedNormal(HIDDEN_DIM, ACTION_DIM),
+            FullyConnectedNormal(HIDDEN_DIM, 1, squeeze_feature_dim=True),
+        )
+
+        # Create policy network
+        policy_net = PolicyOrValueNetwork(
+            nn.Identity(),
+            nn.Identity(),
+            SelectObservation(),
+            nn.Linear(OBSERVATION_DIM, HIDDEN_DIM),
+            FullyConnectedNormal(HIDDEN_DIM, ACTION_DIM),
+        )
+
+        # Create value network
+        value_net = PolicyOrValueNetwork(
+            nn.Identity(),
+            nn.Identity(),
+            SelectObservation(),
+            nn.Linear(OBSERVATION_DIM, HIDDEN_DIM),
+            FullyConnectedNormal(HIDDEN_DIM, 1, squeeze_feature_dim=True),
+        )
+
+        return {
+            ModelNames.FORWARD_DYNAMICS: ModelWrapper(forward_dynamics, device, True),
+            ModelNames.POLICY: ModelWrapper(policy_net, device, True),
+            ModelNames.VALUE: ModelWrapper(value_net, device, True),
+        }
+
+    @pytest.fixture
+    def inference_models(self, models) -> InferenceWrappersDict:
+        mwd = ModelWrappersDict(models)
+        mwd.send_to_default_device()
+
+        return mwd.inference_wrappers_dict
+
+    @pytest.fixture
+    def inference_models_policy_value_common(self, models) -> InferenceWrappersDict:
+        del models[ModelNames.POLICY]
+        del models[ModelNames.VALUE]
+        policy_value = PolicyValueCommonNet(
+            nn.Identity(),
+            nn.Identity(),
+            SelectObservation(),
+            nn.Linear(OBSERVATION_DIM, HIDDEN_DIM),
+            FullyConnectedNormal(HIDDEN_DIM, ACTION_DIM),
+            FullyConnectedValueHead(HIDDEN_DIM, squeeze_value_dim=True),
+        )
+        models[ModelNames.POLICY_VALUE] = ModelWrapper(policy_value)
+        mwd = ModelWrappersDict(models)
+        mwd.send_to_default_device()
+        return mwd.inference_wrappers_dict
+
+    @pytest.fixture
+    def data_collectors(self) -> DataCollectorsDict:
+        empty_buffer = RandomDataBuffer(10, [DataKeys.OBSERVATION])
+        return DataCollectorsDict.from_data_buffers(
+            **{
+                BufferNames.FORWARD_DYNAMICS_TRAJECTORY: empty_buffer,
+                BufferNames.PPO_TRAJECTORY: empty_buffer,
+            }
+        )
+
+    @pytest.fixture
+    def logger(self, tmp_path):
+        return TimeIntervalLogger(f"{tmp_path}/tensorboard", 0)
+
+    @pytest.fixture
+    def agent(self, inference_models, data_collectors, logger, device) -> CuriosityAgent:
+        curiosity_agent = CuriosityAgent(
+            initial_hidden=torch.zeros(DEPTH, HIDDEN_DIM, device=device),
+            logger=logger,
+            max_imagination_steps=3,
+        )
+        curiosity_agent.attach_data_collectors(data_collectors)
+        curiosity_agent.attach_inference_models(inference_models)
+        return curiosity_agent
+
+    def test_setup_step_teardown(self, agent: CuriosityAgent):
+        """Test the main interaction loop of the agent."""
+        observation = torch.randn(OBSERVATION_DIM)
+        agent.setup()
+
+        assert agent.initial_step
+        for _ in range(10):
+            action = agent.step(observation)
+            assert not agent.initial_step
+            assert action.shape == (ACTION_DIM,)
+            assert isinstance(action, torch.Tensor)
+
+        # Check step data shapes
+        assert agent.step_data[DataKeys.OBSERVATION].shape == (OBSERVATION_DIM,)
+        assert agent.step_data[DataKeys.ACTION].shape == (ACTION_DIM,)
+        assert agent.step_data[DataKeys.ACTION_LOG_PROBABILITY].shape == (ACTION_DIM,)
+        assert agent.step_data[DataKeys.VALUE].shape == ()
+        assert agent.step_data[DataKeys.HIDDEN].shape == (DEPTH, HIDDEN_DIM)
+        assert agent.step_data[DataKeys.REWARD].shape == ()
+
+        # Check imagination states
+        assert isinstance(agent.obs_dist_imaginations, Distribution)
+        assert len(agent.obs_imaginations) == 3
+        assert isinstance(agent.obs_imaginations, torch.Tensor)
+        assert len(agent.forward_dynamics_hidden_imaginations) == 3
+        assert isinstance(agent.forward_dynamics_hidden_imaginations, torch.Tensor)
+
+    def test_save_and_load_state(self, agent: CuriosityAgent, tmp_path):
+        """Test state saving and loading functionality."""
+        agent_path = tmp_path / "agent"
+        agent.save_state(agent_path)
+        assert (agent_path / "head_forward_dynamics_hidden_state.pt").exists()
+
+        # Modify state and verify it's different
+        hidden = agent.head_forward_dynamics_hidden_state.clone()
+        agent.head_forward_dynamics_hidden_state = torch.randn_like(hidden)
+        assert not torch.equal(agent.head_forward_dynamics_hidden_state, hidden)
+
+        # Load state and verify it's restored
+        agent.load_state(agent_path)
+        assert torch.equal(agent.head_forward_dynamics_hidden_state, hidden)
+
+    def test_initialization_with_invalid_steps(self):
+        """Test that agent raises error for invalid max_imagination_steps."""
+        with pytest.raises(ValueError):
+            CuriosityAgent(initial_hidden=torch.zeros(DEPTH, HIDDEN_DIM), logger=None, max_imagination_steps=0)
+
+    def test_policy_value_common_net(self, inference_models_policy_value_common, data_collectors, logger, device):
+        """Test agent with combined policy-value network."""
+
+        # Create agent with combined network
+        agent = CuriosityAgent(
+            initial_hidden=torch.zeros(DEPTH, HIDDEN_DIM, device=device),
+            logger=logger,
+            max_imagination_steps=3,
+        )
+        agent.attach_data_collectors(data_collectors)
+        agent.attach_inference_models(inference_models_policy_value_common)
+
+        # Test that agent works with combined network
+        observation = torch.randn(OBSERVATION_DIM)
+        agent.setup()
+        action = agent.step(observation)
+        assert action.shape == (ACTION_DIM,)


### PR DESCRIPTION
## 概要

#247 MultistepImaginationImageCuriosityAgentのコア部分を抽出し、再利用性やパーツとして使えるような実装にしました。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
