### PR TITLE
MultiModalTemporalCuriosityAgent

### DIFF
--- a/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
+++ b/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
@@ -22,6 +22,17 @@ class MultimodalTemporalCuriosityAgent(BaseAgent[Mapping[Modality, Tensor], Tens
         include_action_modality: bool,
         initial_action: Tensor | None = None,
     ) -> None:
+        """Initializes the MultimodalTemporalCuriosityAgent.
+
+        Args:
+            multimodal_temporal_agent (MultimodalTemporalEncodingAgent): The agent for multimodal temporal encoding
+            curiosity_agent (CuriosityAgent): The agent of curiosity-driven exploration.
+            include_action_modality (bool): If true, add loopback action modality to observation.
+            initial_action (Tensor | None, optional): Initial action for action modality. Defaults to None.
+
+        Raises:
+            ValueError: If `initial_action` is None when including action modality.
+        """
         super().__init__(multimodal_temporal_agent, curiosity_agent)
 
         self.multimodal_temporal_agent = multimodal_temporal_agent

--- a/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
+++ b/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
@@ -1,0 +1,65 @@
+from collections.abc import Mapping
+from pathlib import Path
+
+from torch import Tensor
+
+from ami.utils import Modality
+
+from .base_agent import BaseAgent
+from .curiosity_agent import CuriosityAgent
+from .multimodal_temporal_encoding_agent import MultimodalTemporalEncodingAgent
+from .unimodal_encoding_agent import UnimodalEncodingAgent
+
+
+class MultimodalTemporalCuriosityAgent(BaseAgent[Mapping[Modality, Tensor], Tensor]):
+    """Agent that combines multimodal encoding, temporal encoding, and
+    curiosity-driven exploration.
+
+    This agent processes multimodal observations through:
+    1. Unimodal encoding for each modality
+    2. Temporal encoding of combined multimodal features
+    3. Curiosity-driven action selection
+    """
+
+    def __init__(
+        self,
+        unimodal_agents: Mapping[Modality, UnimodalEncodingAgent],
+        temporal_agent: MultimodalTemporalEncodingAgent,
+        curiosity_agent: CuriosityAgent,
+    ) -> None:
+        super().__init__(*unimodal_agents.values(), temporal_agent, curiosity_agent)
+
+        self.unimodal_agents = unimodal_agents
+        self.temporal_agent = temporal_agent
+        self.curiosity_agent = curiosity_agent
+
+    def step(self, observation: Mapping[Modality, Tensor]) -> Tensor:
+        """Process multimodal observation and return action."""
+
+        # Step 1: Unimodal encoding
+        encoded_obs = {}
+        for modality, agent in self.unimodal_agents.items():
+            encoded_obs[modality] = agent.step(observation[modality])
+
+        # Step 2: Temporal encoding
+        temporal_encoded = self.temporal_agent.step(encoded_obs)
+
+        # Step 3: Curiosity-driven action selection
+        action = self.curiosity_agent.step(temporal_encoded)
+
+        return action
+
+    def save_state(self, path: Path) -> None:
+        super().save_state(path)
+        path.mkdir()
+        for modality, agent in self.unimodal_agents.items():
+            agent.save_state(path / modality)
+        self.temporal_agent.save_state(path / "temporal")
+        self.curiosity_agent.save_state(path / "curiosity")
+
+    def load_state(self, path: Path) -> None:
+        super().load_state(path)
+        for modality, agent in self.unimodal_agents.items():
+            agent.load_state(path / modality)
+        self.temporal_agent.load_state(path / "temporal")
+        self.curiosity_agent.load_state(path / "curiosity")

--- a/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
+++ b/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
@@ -26,12 +26,19 @@ class MultimodalTemporalCuriosityAgent(BaseAgent[Mapping[Modality, Tensor], Tens
         unimodal_agents: Mapping[Modality, UnimodalEncodingAgent],
         temporal_agent: MultimodalTemporalEncodingAgent,
         curiosity_agent: CuriosityAgent,
+        include_action_modality: bool,
+        initial_action: Tensor | None = None,
     ) -> None:
         super().__init__(*unimodal_agents.values(), temporal_agent, curiosity_agent)
 
         self.unimodal_agents = unimodal_agents
         self.temporal_agent = temporal_agent
         self.curiosity_agent = curiosity_agent
+        if include_action_modality and initial_action is None:
+            raise ValueError("Must provide `initial_action` tensor with including action modality.")
+
+        self._include_action_modality = include_action_modality
+        self._previous_action = initial_action
 
     def step(self, observation: Mapping[Modality, Tensor]) -> Tensor:
         """Process multimodal observation and return action."""
@@ -40,12 +47,17 @@ class MultimodalTemporalCuriosityAgent(BaseAgent[Mapping[Modality, Tensor], Tens
         encoded_obs = {}
         for modality, agent in self.unimodal_agents.items():
             encoded_obs[modality] = agent.step(observation[modality])
+        if self._previous_action is not None:
+            encoded_obs[Modality.ACTION] = self._previous_action
 
         # Step 2: Temporal encoding
         temporal_encoded = self.temporal_agent.step(encoded_obs)
 
         # Step 3: Curiosity-driven action selection
         action = self.curiosity_agent.step(temporal_encoded)
+
+        if self._include_action_modality:
+            self._previous_action = action.clone()
 
         return action
 

--- a/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
+++ b/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from pathlib import Path
 
+import torch
 from torch import Tensor
 
 from ami.utils import Modality
@@ -69,9 +70,13 @@ class MultimodalTemporalCuriosityAgent(BaseAgent[Mapping[Modality, Tensor], Tens
         self.temporal_agent.save_state(path / "temporal")
         self.curiosity_agent.save_state(path / "curiosity")
 
+        torch.save(self._previous_action, path / "previous_action.pt")
+
     def load_state(self, path: Path) -> None:
         super().load_state(path)
         for modality, agent in self.unimodal_agents.items():
             agent.load_state(path / modality)
         self.temporal_agent.load_state(path / "temporal")
         self.curiosity_agent.load_state(path / "curiosity")
+
+        self._previous_action = torch.load(path / "previous_action.pt")

--- a/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
+++ b/ami/interactions/agents/multimodal_temporal_curiosity_agent.py
@@ -9,31 +9,22 @@ from ami.utils import Modality
 from .base_agent import BaseAgent
 from .curiosity_agent import CuriosityAgent
 from .multimodal_temporal_encoding_agent import MultimodalTemporalEncodingAgent
-from .unimodal_encoding_agent import UnimodalEncodingAgent
 
 
 class MultimodalTemporalCuriosityAgent(BaseAgent[Mapping[Modality, Tensor], Tensor]):
     """Agent that combines multimodal encoding, temporal encoding, and
-    curiosity-driven exploration.
-
-    This agent processes multimodal observations through:
-    1. Unimodal encoding for each modality
-    2. Temporal encoding of combined multimodal features
-    3. Curiosity-driven action selection
-    """
+    curiosity-driven exploration."""
 
     def __init__(
         self,
-        unimodal_agents: Mapping[Modality, UnimodalEncodingAgent],
-        temporal_agent: MultimodalTemporalEncodingAgent,
+        multimodal_temporal_agent: MultimodalTemporalEncodingAgent,
         curiosity_agent: CuriosityAgent,
         include_action_modality: bool,
         initial_action: Tensor | None = None,
     ) -> None:
-        super().__init__(*unimodal_agents.values(), temporal_agent, curiosity_agent)
+        super().__init__(multimodal_temporal_agent, curiosity_agent)
 
-        self.unimodal_agents = unimodal_agents
-        self.temporal_agent = temporal_agent
+        self.multimodal_temporal_agent = multimodal_temporal_agent
         self.curiosity_agent = curiosity_agent
         if include_action_modality and initial_action is None:
             raise ValueError("Must provide `initial_action` tensor with including action modality.")
@@ -44,18 +35,14 @@ class MultimodalTemporalCuriosityAgent(BaseAgent[Mapping[Modality, Tensor], Tens
     def step(self, observation: Mapping[Modality, Tensor]) -> Tensor:
         """Process multimodal observation and return action."""
 
-        # Step 1: Unimodal encoding
-        encoded_obs = {}
-        for modality, agent in self.unimodal_agents.items():
-            encoded_obs[modality] = agent.step(observation[modality])
+        observation = dict(observation)  # copy
+
         if self._previous_action is not None:
-            encoded_obs[Modality.ACTION] = self._previous_action
+            observation[Modality.ACTION] = self._previous_action
 
-        # Step 2: Temporal encoding
-        temporal_encoded = self.temporal_agent.step(encoded_obs)
+        encoded = self.multimodal_temporal_agent.step(observation)
 
-        # Step 3: Curiosity-driven action selection
-        action = self.curiosity_agent.step(temporal_encoded)
+        action = self.curiosity_agent.step(encoded)
 
         if self._include_action_modality:
             self._previous_action = action.clone()
@@ -65,18 +52,14 @@ class MultimodalTemporalCuriosityAgent(BaseAgent[Mapping[Modality, Tensor], Tens
     def save_state(self, path: Path) -> None:
         super().save_state(path)
         path.mkdir()
-        for modality, agent in self.unimodal_agents.items():
-            agent.save_state(path / modality)
-        self.temporal_agent.save_state(path / "temporal")
+        self.multimodal_temporal_agent.save_state(path / "multimodal_temporal")
         self.curiosity_agent.save_state(path / "curiosity")
 
         torch.save(self._previous_action, path / "previous_action.pt")
 
     def load_state(self, path: Path) -> None:
         super().load_state(path)
-        for modality, agent in self.unimodal_agents.items():
-            agent.load_state(path / modality)
-        self.temporal_agent.load_state(path / "temporal")
+        self.multimodal_temporal_agent.load_state(path / "multimodal_temporal")
         self.curiosity_agent.load_state(path / "curiosity")
 
         self._previous_action = torch.load(path / "previous_action.pt")

--- a/ami/utils.py
+++ b/ami/utils.py
@@ -35,3 +35,4 @@ class Modality(str, Enum):
 
     IMAGE = "image"
     AUDIO = "audio"
+    ACTION = "action"

--- a/tests/interactions/agents/test_multimodal_temporal_curiosity_agent.py
+++ b/tests/interactions/agents/test_multimodal_temporal_curiosity_agent.py
@@ -9,7 +9,6 @@ from ami.interactions.agents.multimodal_temporal_curiosity_agent import (
 from ami.interactions.agents.multimodal_temporal_encoding_agent import (
     MultimodalTemporalEncodingAgent,
 )
-from ami.interactions.agents.unimodal_encoding_agent import UnimodalEncodingAgent
 from ami.utils import Modality
 
 # Test constants
@@ -19,19 +18,8 @@ ACTION_DIM = 8
 
 class TestMultimodalTemporalCuriosityAgent:
     @pytest.fixture
-    def mock_unimodal_agents(self, mocker: MockerFixture):
-        """Create mock unimodal agents for each modality."""
-        agents = {}
-        # Using actual Modality enum values
-        for modality in [Modality.IMAGE, Modality.AUDIO]:
-            mock_agent = mocker.create_autospec(UnimodalEncodingAgent, instance=True)
-            mock_agent.step.return_value = torch.randn(OBSERVATION_DIM)
-            agents[modality] = mock_agent
-        return agents
-
-    @pytest.fixture
-    def mock_temporal_agent(self, mocker: MockerFixture):
-        """Create mock temporal encoding agent."""
+    def mock_multimodal_temporal_agent(self, mocker: MockerFixture):
+        """Create mock multimodal temporal encoding agent."""
         mock_agent = mocker.create_autospec(MultimodalTemporalEncodingAgent, instance=True)
         mock_agent.step.return_value = torch.randn(OBSERVATION_DIM)
         return mock_agent
@@ -44,23 +32,21 @@ class TestMultimodalTemporalCuriosityAgent:
         return mock_agent
 
     @pytest.fixture
-    def agent_without_action(self, mock_unimodal_agents, mock_temporal_agent, mock_curiosity_agent):
+    def agent_without_action(self, mock_multimodal_temporal_agent, mock_curiosity_agent):
         """Create agent instance without action modality."""
         return MultimodalTemporalCuriosityAgent(
-            unimodal_agents=mock_unimodal_agents,
-            temporal_agent=mock_temporal_agent,
+            multimodal_temporal_agent=mock_multimodal_temporal_agent,
             curiosity_agent=mock_curiosity_agent,
             include_action_modality=False,
             initial_action=None,
         )
 
     @pytest.fixture
-    def agent_with_action(self, mock_unimodal_agents, mock_temporal_agent, mock_curiosity_agent):
+    def agent_with_action(self, mock_multimodal_temporal_agent, mock_curiosity_agent):
         """Create agent instance with action modality."""
         initial_action = torch.randn(ACTION_DIM)
         return MultimodalTemporalCuriosityAgent(
-            unimodal_agents=mock_unimodal_agents,
-            temporal_agent=mock_temporal_agent,
+            multimodal_temporal_agent=mock_multimodal_temporal_agent,
             curiosity_agent=mock_curiosity_agent,
             include_action_modality=True,
             initial_action=initial_action,
@@ -82,12 +68,11 @@ class TestMultimodalTemporalCuriosityAgent:
         assert agent_with_action._previous_action is not None
         assert agent_with_action._previous_action.shape == (ACTION_DIM,)
 
-    def test_initialization_invalid_config(self, mock_unimodal_agents, mock_temporal_agent, mock_curiosity_agent):
+    def test_initialization_invalid_config(self, mock_multimodal_temporal_agent, mock_curiosity_agent):
         """Test initialization with invalid configuration."""
         with pytest.raises(ValueError):
             MultimodalTemporalCuriosityAgent(
-                unimodal_agents=mock_unimodal_agents,
-                temporal_agent=mock_temporal_agent,
+                multimodal_temporal_agent=mock_multimodal_temporal_agent,
                 curiosity_agent=mock_curiosity_agent,
                 include_action_modality=True,
                 initial_action=None,
@@ -95,23 +80,32 @@ class TestMultimodalTemporalCuriosityAgent:
 
     def test_step_without_action(self, agent_without_action, sample_observation):
         """Test step function without action modality."""
+        # Store original observation for comparison
+        orig_observation = {k: v.clone() for k, v in sample_observation.items()}
+
         action = agent_without_action.step(sample_observation)
 
         # Verify action shape
         assert isinstance(action, torch.Tensor)
         assert action.shape == (ACTION_DIM,)
 
-        # Verify each unimodal agent was called
-        for modality, agent in agent_without_action.unimodal_agents.items():
-            agent.step.assert_called_once_with(sample_observation[modality])
+        # Verify multimodal_temporal_agent was called with correct input
+        agent_without_action.multimodal_temporal_agent.step.assert_called_once()
+        multimodal_input = agent_without_action.multimodal_temporal_agent.step.call_args[0][0]
+        assert Modality.ACTION not in multimodal_input
+        for modality in orig_observation:
+            assert torch.equal(multimodal_input[modality], orig_observation[modality])
 
-        # Verify temporal and curiosity agents were called
-        agent_without_action.temporal_agent.step.assert_called_once()
+        # Verify curiosity agent was called with encoded observation
         agent_without_action.curiosity_agent.step.assert_called_once()
+        encoded_input = agent_without_action.curiosity_agent.step.call_args[0][0]
+        assert torch.equal(encoded_input, agent_without_action.multimodal_temporal_agent.step.return_value)
 
     def test_step_with_action(self, agent_with_action, sample_observation):
         """Test step function with action modality."""
         initial_action = agent_with_action._previous_action.clone()
+        orig_observation = {k: v.clone() for k, v in sample_observation.items()}
+
         action = agent_with_action.step(sample_observation)
 
         # Verify action shape and previous action update
@@ -120,10 +114,18 @@ class TestMultimodalTemporalCuriosityAgent:
         assert not torch.equal(agent_with_action._previous_action, initial_action)
         assert torch.equal(agent_with_action._previous_action, action)
 
-        # Verify temporal agent received correct input including action
-        temporal_input = agent_with_action.temporal_agent.step.call_args[0][0]
-        assert Modality.ACTION in temporal_input
-        assert torch.equal(temporal_input[Modality.ACTION], initial_action)
+        # Verify multimodal_temporal_agent received correct input including action
+        agent_with_action.multimodal_temporal_agent.step.assert_called_once()
+        multimodal_input = agent_with_action.multimodal_temporal_agent.step.call_args[0][0]
+        assert Modality.ACTION in multimodal_input
+        assert torch.equal(multimodal_input[Modality.ACTION], initial_action)
+        for modality in orig_observation:
+            assert torch.equal(multimodal_input[modality], orig_observation[modality])
+
+        # Verify curiosity agent was called with encoded observation
+        agent_with_action.curiosity_agent.step.assert_called_once()
+        encoded_input = agent_with_action.curiosity_agent.step.call_args[0][0]
+        assert torch.equal(encoded_input, agent_with_action.multimodal_temporal_agent.step.return_value)
 
     def test_save_and_load_state(self, agent_with_action, tmp_path):
         """Test state saving and loading functionality."""
@@ -132,30 +134,27 @@ class TestMultimodalTemporalCuriosityAgent:
         # Save state
         agent_with_action.save_state(save_path)
 
-        # Verify component agents' save_state was called
-        for agent in agent_with_action.unimodal_agents.values():
-            agent.save_state.assert_called_once()
-        agent_with_action.temporal_agent.save_state.assert_called_once()
-        agent_with_action.curiosity_agent.save_state.assert_called_once()
+        # Verify component agents' save_state was called with correct paths
+        agent_with_action.multimodal_temporal_agent.save_state.assert_called_once_with(
+            save_path / "multimodal_temporal"
+        )
+        agent_with_action.curiosity_agent.save_state.assert_called_once_with(save_path / "curiosity")
 
         # Verify previous_action was saved
         assert (save_path / "previous_action.pt").exists()
 
         # Load state
         new_agent = MultimodalTemporalCuriosityAgent(
-            unimodal_agents=agent_with_action.unimodal_agents,
-            temporal_agent=agent_with_action.temporal_agent,
+            multimodal_temporal_agent=agent_with_action.multimodal_temporal_agent,
             curiosity_agent=agent_with_action.curiosity_agent,
             include_action_modality=True,
             initial_action=torch.randn(ACTION_DIM),  # Different initial action
         )
         new_agent.load_state(save_path)
 
-        # Verify component agents' load_state was called
-        for agent in new_agent.unimodal_agents.values():
-            agent.load_state.assert_called_once()
-        new_agent.temporal_agent.load_state.assert_called_once()
-        new_agent.curiosity_agent.load_state.assert_called_once()
+        # Verify component agents' load_state was called with correct paths
+        new_agent.multimodal_temporal_agent.load_state.assert_called_once_with(save_path / "multimodal_temporal")
+        new_agent.curiosity_agent.load_state.assert_called_once_with(save_path / "curiosity")
 
         # Verify previous_action was loaded correctly
         assert torch.equal(new_agent._previous_action, agent_with_action._previous_action)
@@ -164,14 +163,10 @@ class TestMultimodalTemporalCuriosityAgent:
         """Test setup and teardown methods."""
         # Test setup
         agent_with_action.setup()
-        for agent in agent_with_action.unimodal_agents.values():
-            agent.setup.assert_called_once()
-        agent_with_action.temporal_agent.setup.assert_called_once()
+        agent_with_action.multimodal_temporal_agent.setup.assert_called_once()
         agent_with_action.curiosity_agent.setup.assert_called_once()
 
         # Test teardown
         agent_with_action.teardown()
-        for agent in agent_with_action.unimodal_agents.values():
-            agent.teardown.assert_called_once()
-        agent_with_action.temporal_agent.teardown.assert_called_once()
+        agent_with_action.multimodal_temporal_agent.teardown.assert_called_once()
         agent_with_action.curiosity_agent.teardown.assert_called_once()

--- a/tests/interactions/agents/test_multimodal_temporal_curiosity_agent.py
+++ b/tests/interactions/agents/test_multimodal_temporal_curiosity_agent.py
@@ -1,0 +1,177 @@
+import pytest
+import torch
+from pytest_mock import MockerFixture
+
+from ami.interactions.agents.curiosity_agent import CuriosityAgent
+from ami.interactions.agents.multimodal_temporal_curiosity_agent import (
+    MultimodalTemporalCuriosityAgent,
+)
+from ami.interactions.agents.multimodal_temporal_encoding_agent import (
+    MultimodalTemporalEncodingAgent,
+)
+from ami.interactions.agents.unimodal_encoding_agent import UnimodalEncodingAgent
+from ami.utils import Modality
+
+# Test constants
+OBSERVATION_DIM = 64
+ACTION_DIM = 8
+
+
+class TestMultimodalTemporalCuriosityAgent:
+    @pytest.fixture
+    def mock_unimodal_agents(self, mocker: MockerFixture):
+        """Create mock unimodal agents for each modality."""
+        agents = {}
+        # Using actual Modality enum values
+        for modality in [Modality.IMAGE, Modality.AUDIO]:
+            mock_agent = mocker.create_autospec(UnimodalEncodingAgent, instance=True)
+            mock_agent.step.return_value = torch.randn(OBSERVATION_DIM)
+            agents[modality] = mock_agent
+        return agents
+
+    @pytest.fixture
+    def mock_temporal_agent(self, mocker: MockerFixture):
+        """Create mock temporal encoding agent."""
+        mock_agent = mocker.create_autospec(MultimodalTemporalEncodingAgent, instance=True)
+        mock_agent.step.return_value = torch.randn(OBSERVATION_DIM)
+        return mock_agent
+
+    @pytest.fixture
+    def mock_curiosity_agent(self, mocker: MockerFixture):
+        """Create mock curiosity agent."""
+        mock_agent = mocker.create_autospec(CuriosityAgent, instance=True)
+        mock_agent.step.return_value = torch.randn(ACTION_DIM)
+        return mock_agent
+
+    @pytest.fixture
+    def agent_without_action(self, mock_unimodal_agents, mock_temporal_agent, mock_curiosity_agent):
+        """Create agent instance without action modality."""
+        return MultimodalTemporalCuriosityAgent(
+            unimodal_agents=mock_unimodal_agents,
+            temporal_agent=mock_temporal_agent,
+            curiosity_agent=mock_curiosity_agent,
+            include_action_modality=False,
+            initial_action=None,
+        )
+
+    @pytest.fixture
+    def agent_with_action(self, mock_unimodal_agents, mock_temporal_agent, mock_curiosity_agent):
+        """Create agent instance with action modality."""
+        initial_action = torch.randn(ACTION_DIM)
+        return MultimodalTemporalCuriosityAgent(
+            unimodal_agents=mock_unimodal_agents,
+            temporal_agent=mock_temporal_agent,
+            curiosity_agent=mock_curiosity_agent,
+            include_action_modality=True,
+            initial_action=initial_action,
+        )
+
+    @pytest.fixture
+    def sample_observation(self):
+        """Create sample observation for testing."""
+        return {Modality.IMAGE: torch.randn(OBSERVATION_DIM), Modality.AUDIO: torch.randn(OBSERVATION_DIM)}
+
+    def test_initialization_without_action(self, agent_without_action):
+        """Test initialization without action modality."""
+        assert not agent_without_action._include_action_modality
+        assert agent_without_action._previous_action is None
+
+    def test_initialization_with_action(self, agent_with_action):
+        """Test initialization with action modality."""
+        assert agent_with_action._include_action_modality
+        assert agent_with_action._previous_action is not None
+        assert agent_with_action._previous_action.shape == (ACTION_DIM,)
+
+    def test_initialization_invalid_config(self, mock_unimodal_agents, mock_temporal_agent, mock_curiosity_agent):
+        """Test initialization with invalid configuration."""
+        with pytest.raises(ValueError):
+            MultimodalTemporalCuriosityAgent(
+                unimodal_agents=mock_unimodal_agents,
+                temporal_agent=mock_temporal_agent,
+                curiosity_agent=mock_curiosity_agent,
+                include_action_modality=True,
+                initial_action=None,
+            )
+
+    def test_step_without_action(self, agent_without_action, sample_observation):
+        """Test step function without action modality."""
+        action = agent_without_action.step(sample_observation)
+
+        # Verify action shape
+        assert isinstance(action, torch.Tensor)
+        assert action.shape == (ACTION_DIM,)
+
+        # Verify each unimodal agent was called
+        for modality, agent in agent_without_action.unimodal_agents.items():
+            agent.step.assert_called_once_with(sample_observation[modality])
+
+        # Verify temporal and curiosity agents were called
+        agent_without_action.temporal_agent.step.assert_called_once()
+        agent_without_action.curiosity_agent.step.assert_called_once()
+
+    def test_step_with_action(self, agent_with_action, sample_observation):
+        """Test step function with action modality."""
+        initial_action = agent_with_action._previous_action.clone()
+        action = agent_with_action.step(sample_observation)
+
+        # Verify action shape and previous action update
+        assert isinstance(action, torch.Tensor)
+        assert action.shape == (ACTION_DIM,)
+        assert not torch.equal(agent_with_action._previous_action, initial_action)
+        assert torch.equal(agent_with_action._previous_action, action)
+
+        # Verify temporal agent received correct input including action
+        temporal_input = agent_with_action.temporal_agent.step.call_args[0][0]
+        assert Modality.ACTION in temporal_input
+        assert torch.equal(temporal_input[Modality.ACTION], initial_action)
+
+    def test_save_and_load_state(self, agent_with_action, tmp_path):
+        """Test state saving and loading functionality."""
+        save_path = tmp_path / "agent_state"
+
+        # Save state
+        agent_with_action.save_state(save_path)
+
+        # Verify component agents' save_state was called
+        for agent in agent_with_action.unimodal_agents.values():
+            agent.save_state.assert_called_once()
+        agent_with_action.temporal_agent.save_state.assert_called_once()
+        agent_with_action.curiosity_agent.save_state.assert_called_once()
+
+        # Verify previous_action was saved
+        assert (save_path / "previous_action.pt").exists()
+
+        # Load state
+        new_agent = MultimodalTemporalCuriosityAgent(
+            unimodal_agents=agent_with_action.unimodal_agents,
+            temporal_agent=agent_with_action.temporal_agent,
+            curiosity_agent=agent_with_action.curiosity_agent,
+            include_action_modality=True,
+            initial_action=torch.randn(ACTION_DIM),  # Different initial action
+        )
+        new_agent.load_state(save_path)
+
+        # Verify component agents' load_state was called
+        for agent in new_agent.unimodal_agents.values():
+            agent.load_state.assert_called_once()
+        new_agent.temporal_agent.load_state.assert_called_once()
+        new_agent.curiosity_agent.load_state.assert_called_once()
+
+        # Verify previous_action was loaded correctly
+        assert torch.equal(new_agent._previous_action, agent_with_action._previous_action)
+
+    def test_setup_and_teardown(self, agent_with_action):
+        """Test setup and teardown methods."""
+        # Test setup
+        agent_with_action.setup()
+        for agent in agent_with_action.unimodal_agents.values():
+            agent.setup.assert_called_once()
+        agent_with_action.temporal_agent.setup.assert_called_once()
+        agent_with_action.curiosity_agent.setup.assert_called_once()
+
+        # Test teardown
+        agent_with_action.teardown()
+        for agent in agent_with_action.unimodal_agents.values():
+            agent.teardown.assert_called_once()
+        agent_with_action.temporal_agent.teardown.assert_called_once()
+        agent_with_action.curiosity_agent.teardown.assert_called_once()

--- a/tests/interactions/agents/test_multimodal_temporal_encoding_agent.py
+++ b/tests/interactions/agents/test_multimodal_temporal_encoding_agent.py
@@ -13,6 +13,7 @@ from ami.data.utils import DataCollectorsDict
 from ami.interactions.agents.multimodal_temporal_encoding_agent import (
     MultimodalTemporalEncodingAgent,
 )
+from ami.interactions.agents.unimodal_encoding_agent import UnimodalEncodingAgent
 from ami.models.components.sioconvps import SioConvPS
 from ami.models.model_names import ModelNames
 from ami.models.model_wrapper import ModelWrapper
@@ -23,20 +24,37 @@ from ami.utils import Modality
 
 class TestMultimodalTemporalEncodingAgent:
     # Define test dimensions
-    IMAGE_DIM = 4
-    AUDIO_DIM = 6
+    RAW_IMAGE_DIM = 8  # Raw image input dimension
+    RAW_AUDIO_DIM = 10  # Raw audio input dimension
+    IMAGE_DIM = 4  # Encoded image dimension
+    AUDIO_DIM = 6  # Encoded audio dimension
     HIDDEN_DIM = 8
     DEPTH = 4
+
+    @pytest.fixture
+    def unimodal_agents(self, mocker: MockerFixture) -> dict[Modality, UnimodalEncodingAgent]:
+        """Create mock unimodal encoding agents.
+
+        These agents should encode raw input dimensions to encoded dimensions:
+        - Image: RAW_IMAGE_DIM -> IMAGE_DIM
+        - Audio: RAW_AUDIO_DIM -> AUDIO_DIM
+        """
+        image_agent = mocker.create_autospec(UnimodalEncodingAgent, instance=True)
+        image_agent.step.return_value = torch.randn(self.IMAGE_DIM)
+        audio_agent = mocker.create_autospec(UnimodalEncodingAgent, instance=True)
+        audio_agent.step.return_value = torch.randn(self.AUDIO_DIM)
+        return {Modality.IMAGE: image_agent, Modality.AUDIO: audio_agent}
 
     @pytest.fixture
     def models(self) -> ModelWrappersDict:
         """Create mock models dictionary for testing.
 
-        Returns:
-            ModelWrappersDict: Dictionary containing all required model wrappers.
+        The MultimodalTemporalEncoder expects encoded inputs from
+        unimodal agents. Input dimensions should match the encoded
+        dimensions (IMAGE_DIM, AUDIO_DIM).
         """
         observation_flattens = {Modality.IMAGE: nn.Identity(), Modality.AUDIO: nn.Identity()}
-        # Project concatenated features (IMAGE_DIM + AUDIO_DIM) to PROJECTION_DIM
+        # Project concatenated encoded features
         flattened_obses_projection = nn.Linear(self.IMAGE_DIM + self.AUDIO_DIM, self.HIDDEN_DIM)
         core_model = SioConvPS(self.DEPTH, self.HIDDEN_DIM, self.HIDDEN_DIM * 2, False)
         obs_hat_dist_heads = {
@@ -59,11 +77,7 @@ class TestMultimodalTemporalEncodingAgent:
 
     @pytest.fixture
     def data_collectors(self) -> DataCollectorsDict:
-        """Create mock data collectors for testing.
-
-        Returns:
-            DataCollectorsDict: Dictionary containing all required data collectors.
-        """
+        """Create mock data collectors for testing."""
         temporal_buf = MultimodalTemporalDataBuffer(max_len=10)
         return DataCollectorsDict.from_data_buffers(
             **{
@@ -72,37 +86,39 @@ class TestMultimodalTemporalEncodingAgent:
         )
 
     @pytest.fixture
-    def agent(self, models, data_collectors, mocker) -> MultimodalTemporalEncodingAgent:
-        """Create a MultimodalTemporalEncodingAgent instance for testing.
-
-        Returns:
-            MultimodalTemporalEncodingAgent: The agent instance for testing.
-        """
-
+    def agent(self, models, data_collectors, unimodal_agents) -> MultimodalTemporalEncodingAgent:
+        """Create a MultimodalTemporalEncodingAgent instance for testing."""
         initial_hidden = torch.zeros(self.DEPTH, self.HIDDEN_DIM)
-        agent = MultimodalTemporalEncodingAgent(initial_hidden)
+        agent = MultimodalTemporalEncodingAgent(initial_hidden, unimodal_agents)
         agent.attach_inference_models(models)
         agent.attach_data_collectors(data_collectors)
         return agent
 
-    def test_step_dimensions(self, agent):
+    def test_step_dimensions(self, agent, unimodal_agents):
         """Test the dimensions of inputs and outputs in the step function."""
-        # Create simple observations
-        observation = {Modality.IMAGE: torch.randn(self.IMAGE_DIM), Modality.AUDIO: torch.randn(self.AUDIO_DIM)}
+        # Create raw observations
+        observation = {Modality.IMAGE: torch.randn(self.RAW_IMAGE_DIM), Modality.AUDIO: torch.randn(self.RAW_AUDIO_DIM)}
+
+        # Store original observation for input verification
+        orig_observation = {k: v.clone() for k, v in observation.items()}
 
         # Test step function
         output = agent.step(observation)
+
+        # Verify unimodal agents were called with correct inputs
+        for modality, unimodal_agent in unimodal_agents.items():
+            unimodal_agent.step.assert_called_once()
+            assert torch.equal(unimodal_agent.step.call_args[0][0], orig_observation[modality])
 
         # Verify dimensions
         assert output.shape == (self.HIDDEN_DIM,)
         assert agent.encoder_hidden_state.shape == (self.DEPTH, self.HIDDEN_DIM)
 
-    def test_temporal_encoding(self, agent):
+    def test_temporal_encoding(self, agent, unimodal_agents):
         """Test if temporal information is being encoded properly."""
-        # Create two different observations
-        obs1 = {Modality.IMAGE: torch.ones(self.IMAGE_DIM), Modality.AUDIO: torch.ones(self.AUDIO_DIM)}
-
-        obs2 = {Modality.IMAGE: torch.zeros(self.IMAGE_DIM), Modality.AUDIO: torch.zeros(self.AUDIO_DIM)}
+        # Create two different raw observations
+        obs1 = {Modality.IMAGE: torch.ones(self.RAW_IMAGE_DIM), Modality.AUDIO: torch.ones(self.RAW_AUDIO_DIM)}
+        obs2 = {Modality.IMAGE: torch.zeros(self.RAW_IMAGE_DIM), Modality.AUDIO: torch.zeros(self.RAW_AUDIO_DIM)}
 
         # Process sequences and verify hidden states change
         hidden_state_1 = agent.encoder_hidden_state.clone()
@@ -115,10 +131,20 @@ class TestMultimodalTemporalEncodingAgent:
         assert not torch.allclose(hidden_state_1, hidden_state_2)
         assert not torch.allclose(hidden_state_2, hidden_state_3)
 
-    def test_buffer_collection(self, agent: MultimodalTemporalEncodingAgent):
+        # Verify unimodal agents were called with correct inputs
+        for modality, unimodal_agent in unimodal_agents.items():
+            assert unimodal_agent.step.call_count == 2
+            assert torch.equal(unimodal_agent.step.call_args_list[0][0][0], obs1[modality])
+            assert torch.equal(unimodal_agent.step.call_args_list[1][0][0], obs2[modality])
+
+    def test_buffer_collection(self, agent: MultimodalTemporalEncodingAgent, unimodal_agents):
         """Test if observations and hidden states are being collected
         properly."""
-        observation = {Modality.IMAGE: torch.randn(self.IMAGE_DIM), Modality.AUDIO: torch.randn(self.AUDIO_DIM)}
+        observation = {Modality.IMAGE: torch.randn(self.RAW_IMAGE_DIM), Modality.AUDIO: torch.randn(self.RAW_AUDIO_DIM)}
+
+        # Store original observation and current hidden state
+        orig_observation = {k: v.clone() for k, v in observation.items()}
+        orig_hidden = agent.encoder_hidden_state.clone()
 
         initial_buffer_size = len(agent.collector._buffer)
         _ = agent.step(observation)
@@ -131,16 +157,43 @@ class TestMultimodalTemporalEncodingAgent:
         dataset = buffer.make_dataset()
         assert len(dataset) == len(buffer)
 
-    def test_save_load_state(self, agent: MultimodalTemporalEncodingAgent, tmp_path: Path, mocker: MockerFixture):
+        # Verify the collected data
+        last_data = dataset[-1]
+        observation, hidden = last_data
+        assert torch.equal(hidden, orig_hidden)
+
+        # Verify encoded observations were stored
+        for modality, unimodal_agent in unimodal_agents.items():
+            assert torch.equal(unimodal_agent.step.call_args[0][0], orig_observation[modality])
+            assert torch.equal(observation[modality], unimodal_agent.step.return_value)
+
+    def test_save_load_state(self, agent: MultimodalTemporalEncodingAgent, tmp_path: Path, unimodal_agents):
         """Test the state saving and loading functionality."""
         agent_path = tmp_path / "agent"
 
+        # Generate some initial states
+        orig_hidden = agent.encoder_hidden_state.clone()
+
+        # Test save state
         agent.save_state(agent_path)
         assert (agent_path / "encoder_hidden_state.pt").exists()
 
-        hidden = agent.encoder_hidden_state.clone()
-        agent.encoder_hidden_state.random_()
-        assert not torch.equal(agent.encoder_hidden_state, hidden)
+        # Verify save was called for each unimodal agent with correct paths
+        for modality, unimodal_agent in unimodal_agents.items():
+            expected_path = agent_path / modality
+            unimodal_agent.save_state.assert_called_once_with(expected_path)
 
+        # Modify states
+        agent.encoder_hidden_state.random_()
+        assert not torch.equal(agent.encoder_hidden_state, orig_hidden)
+
+        # Test load state
         agent.load_state(agent_path)
-        assert torch.equal(agent.encoder_hidden_state, hidden)
+
+        # Verify states were restored
+        assert torch.equal(agent.encoder_hidden_state, orig_hidden)
+
+        # Verify load was called for each unimodal agent with correct paths
+        for modality, unimodal_agent in unimodal_agents.items():
+            expected_path = agent_path / modality
+            unimodal_agent.load_state.assert_called_once_with(expected_path)


### PR DESCRIPTION
## 概要

#251 に加えて、actionをtemporal encoderが受け取れるようにしました。

MultimodalEncodingAgentの内部でUnimodalEncodingAgentを使用するように修正しました。

## 変更内容


## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
