### PR TITLE
SioConvPSをPolicyに採用し、実験を実行

### DIFF
--- a/ami/models/components/stacked_hidden_state.py
+++ b/ami/models/components/stacked_hidden_state.py
@@ -68,24 +68,3 @@ class StackedHiddenSelection(nn.Module):
         hidden_stack = hidden_stack @ self._weight.softmax(0)
         hidden_stack = hidden_stack.transpose(-1, -2)
         return hidden_stack
-
-
-class StackwiseLinear(nn.Module):
-    """Apply `nn.Linear` to hidden stacking dimension."""
-
-    def __init__(self, in_stacks: int, out_stacks: int) -> None:
-        super().__init__()
-        self._linear = nn.Linear(in_stacks, out_stacks)
-
-    def forward(self, hidden_stack: Tensor) -> Tensor:
-        """
-        Args:
-            hidden_stack (Tensor): shape is (*, in_stacks, dim)
-
-        Returns:
-            Tensor: shape is (*, out_stacks, dim)
-        """
-        hidden_stack = hidden_stack.transpose(-1, -2)
-        hidden_stack = self._linear(hidden_stack)
-        hidden_stack = hidden_stack.transpose(-1, -2)
-        return hidden_stack

--- a/ami/models/components/stacked_hidden_state.py
+++ b/ami/models/components/stacked_hidden_state.py
@@ -47,6 +47,29 @@ class StackedHiddenState(nn.Module):
         return x, hidden_out_stack
 
 
+class StackedHiddenSelection(nn.Module):
+    """Selectively maps stacked hidden states to an arbitrary number of
+    stacks."""
+
+    def __init__(self, in_stacks: int, out_stacks: int) -> None:
+        super().__init__()
+        # Initially averages along the stack.
+        self._weight = nn.Parameter(torch.zeros(in_stacks, out_stacks))
+
+    def forward(self, hidden_stack: Tensor) -> Tensor:
+        """
+        Args:
+            hidden_stack (Tensor): shape is (*, in_stacks, dim)
+
+        Returns:
+            Tensor: shape is (*, out_stacks, dim)
+        """
+        hidden_stack = hidden_stack.transpose(-1, -2)
+        hidden_stack = hidden_stack @ self._weight.softmax(0)
+        hidden_stack = hidden_stack.transpose(-1, -2)
+        return hidden_stack
+
+
 class StackwiseLinear(nn.Module):
     """Apply `nn.Linear` to hidden stacking dimension."""
 

--- a/ami/models/components/stacked_hidden_state.py
+++ b/ami/models/components/stacked_hidden_state.py
@@ -45,3 +45,24 @@ class StackedHiddenState(nn.Module):
             hidden_out_stack = hidden_out_stack.squeeze(0)
 
         return x, hidden_out_stack
+
+
+class StackwiseLinear(nn.Module):
+    """Apply `nn.Linear` to hidden stacking dimension."""
+
+    def __init__(self, in_stacks: int, out_stacks: int) -> None:
+        super().__init__()
+        self._linear = nn.Linear(in_stacks, out_stacks)
+
+    def forward(self, hidden_stack: Tensor) -> Tensor:
+        """
+        Args:
+            hidden_stack (Tensor): shape is (*, in_stacks, dim)
+
+        Returns:
+            Tensor: shape is (*, out_stacks, dim)
+        """
+        hidden_stack = hidden_stack.transpose(-1, -2)
+        hidden_stack = self._linear(hidden_stack)
+        hidden_stack = hidden_stack.transpose(-1, -2)
+        return hidden_stack

--- a/configs/experiment/sioconv_policy/blackout.yaml
+++ b/configs/experiment/sioconv_policy/blackout.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+
+defaults:
+  - sioconv_policy/fundamental
+
+interaction:
+  environment:
+    observation_generator:
+      _target_: torch.zeros
+
+subtask_name: blackout

--- a/configs/experiment/sioconv_policy/flickerimage.yaml
+++ b/configs/experiment/sioconv_policy/flickerimage.yaml
@@ -1,0 +1,17 @@
+# @package _global_
+
+defaults:
+  - sioconv_policy/fundamental
+
+interaction:
+  environment:
+    observation_generator:
+      _partial_: false
+      _target_: ami.interactions.environments.image_folder_observation_generator.ImageFolderObservationGenerator
+      _args_:
+        - ${paths.data_dir}/japan_street_images
+      image_size:
+        - ${shared.image_height}
+        - ${shared.image_width}
+
+subtask_name: flickerimage

--- a/configs/experiment/sioconv_policy/fundamental.yaml
+++ b/configs/experiment/sioconv_policy/fundamental.yaml
@@ -71,7 +71,7 @@ trainers:
     entropy_coef: 0.01
     partial_dataloader:
       batch_size: 32
-    max_epochs: 12
+    max_epochs: 6
     # (buffer size / batch size) * epochs = 24 iteration.
 
 max_uptime: ${cvt_time_str:8h}

--- a/configs/experiment/sioconv_policy/fundamental.yaml
+++ b/configs/experiment/sioconv_policy/fundamental.yaml
@@ -68,11 +68,11 @@ trainers:
       max_samples: 64 # Iteraction count.
     minimum_new_data_count: 128
   ppo:
-    entropy_coef: 0.04
+    entropy_coef: 0.01
     partial_dataloader:
-      batch_size: 8
-    max_epochs: 3
-    # 16 (= buffer size / batch size) * epochs = 48 iteration.
+      batch_size: 32
+    max_epochs: 12
+    # (buffer size / batch size) * epochs = 24 iteration.
 
 max_uptime: ${cvt_time_str:8h}
 

--- a/configs/experiment/sioconv_policy/fundamental.yaml
+++ b/configs/experiment/sioconv_policy/fundamental.yaml
@@ -1,0 +1,77 @@
+# @package _global_
+
+# Sioconv Polict の基礎実験用
+
+defaults:
+  - override /interaction/agent: multimodal_temporal_curiosity
+  - override /interaction/environment: dummy_image_io
+  - override /models: sioconv_policy/default.yaml
+  - override /data_collectors: multimodal_temporal_dynamics_ppo
+  - override /trainers: i_jepa_mulitmodal_temporal_dynamics_ppo
+
+shared:
+  image_height: 144
+  image_width: 144
+
+interaction:
+  agent:
+    curiosity_agent:
+      max_imagination_steps: 1 # 0.1 sec
+
+  observation_wrappers:
+    - _target_: ami.interactions.io_wrappers.function_wrapper.FunctionIOWrapper
+      wrap_function:
+        _target_: ami.interactions.io_wrappers.function_wrapper.normalize_tensor
+        _partial_: True
+        eps: 1e-6
+    - _target_: ami.interactions.io_wrappers.function_wrapper.FunctionIOWrapper
+      wrap_function:
+        _target_: ami.interactions.io_wrappers.function_wrapper.to_multimodal_dict
+        _partial_: True
+        modality: image
+
+models:
+  i_jepa_target_encoder:
+    inference_forward:
+      kernel_size: 1
+
+data_collectors:
+  image:
+    max_len: ${python.eval:"24 * ${trainers.i_jepa.partial_dataloader.batch_size}"}
+  multimodal_temporal:
+    max_len: 1000
+  forward_dynamics_trajectory:
+    max_len: 1000 # 100 sec
+  ppo_trajectory:
+    max_len: ${python.eval:"128 + 1"} # +1 to retrieve final next value function output.
+    gamma: 0.97
+
+trainers:
+  i_jepa:
+    max_epochs: 1
+    partial_dataloader:
+      batch_size: 32
+    minimum_new_data_count: 128
+  multimodal_temporal:
+    max_epochs: 1
+    partial_sampler:
+      sequence_length: ${python.eval:"256 + 1"} # +1 to generate future target data.
+      max_samples: 64 # Iteraction count.
+    minimum_new_data_count: 128
+  forward_dynamics:
+    observation_encoder_name: # embed observationを直接使う
+    max_epochs: 1
+    partial_sampler:
+      sequence_length: ${python.eval:"256 + 1"} # +1 to generate future target data.
+      max_samples: 64 # Iteraction count.
+    minimum_new_data_count: 128
+  ppo:
+    entropy_coef: 0.04
+    partial_dataloader:
+      batch_size: 8
+    max_epochs: 3
+    # 16 (= buffer size / batch size) * epochs = 48 iteration.
+
+max_uptime: ${cvt_time_str:8h}
+
+task_name: sioconv_policyf_fundamental

--- a/configs/experiment/sioconv_policy/fundamental.yaml
+++ b/configs/experiment/sioconv_policy/fundamental.yaml
@@ -17,6 +17,8 @@ interaction:
   agent:
     curiosity_agent:
       max_imagination_steps: 1 # 0.1 sec
+    include_action_modality: False
+    initial_action: null
 
   observation_wrappers:
     - _target_: ami.interactions.io_wrappers.function_wrapper.FunctionIOWrapper
@@ -74,4 +76,4 @@ trainers:
 
 max_uptime: ${cvt_time_str:8h}
 
-task_name: sioconv_policyf_fundamental
+task_name: sioconv_policy_fundamental

--- a/configs/experiment/sioconv_policy/fundamental.yaml
+++ b/configs/experiment/sioconv_policy/fundamental.yaml
@@ -68,7 +68,7 @@ trainers:
       max_samples: 64 # Iteraction count.
     minimum_new_data_count: 128
   ppo:
-    entropy_coef: 0.01
+    entropy_coef: 0.04
     partial_dataloader:
       batch_size: 32
     max_epochs: 6

--- a/configs/experiment/sioconv_policy/vrchat.yaml
+++ b/configs/experiment/sioconv_policy/vrchat.yaml
@@ -12,6 +12,6 @@ interaction:
 models:
   i_jepa_target_encoder:
     inference_forward:
-      kernel_size: 2
+      kernel_size: 3
 
 subtask_name: vrchat

--- a/configs/experiment/sioconv_policy/vrchat.yaml
+++ b/configs/experiment/sioconv_policy/vrchat.yaml
@@ -14,4 +14,6 @@ models:
     inference_forward:
       kernel_size: 3
 
+max_uptime: inf
+
 subtask_name: vrchat

--- a/configs/experiment/sioconv_policy/vrchat.yaml
+++ b/configs/experiment/sioconv_policy/vrchat.yaml
@@ -1,0 +1,17 @@
+# @package _global_
+
+defaults:
+  - sioconv_policy/fundamental
+  - override /interaction/environment: vrchat_image_discrete_1st_order_delay
+
+interaction:
+  agent:
+    curiosity_agent:
+      max_imagination_steps: 5 # 0.5 sec
+
+models:
+  i_jepa_target_encoder:
+    inference_forward:
+      kernel_size: 2
+
+subtask_name: vrchat

--- a/configs/experiment/sioconv_policy/whitenoize.yaml
+++ b/configs/experiment/sioconv_policy/whitenoize.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+
+defaults:
+  - sioconv_policy/fundamental
+
+interaction:
+  environment:
+    observation_generator:
+      _target_: torch.randn
+
+subtask_name: whitenoize

--- a/configs/models/sioconv_policy/default.yaml
+++ b/configs/models/sioconv_policy/default.yaml
@@ -1,0 +1,192 @@
+# @package models
+
+# base config is `configs/models/multimodal_temporal/no_action.yaml`
+
+image_encoder: i_jepa_target_encoder # Alias for ImageEncodingAgent.
+
+i_jepa_target_encoder:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: True
+  inference_forward:
+    _target_: ami.models.bool_mask_i_jepa.EncoderInferAveragePool
+    n_patches:
+      - >-
+        ${python.eval:"
+        ${shared.image_height} //
+        ${models.i_jepa_target_encoder.model.patch_size}
+        "}
+      - >-
+        ${python.eval:"
+        ${shared.image_width} //
+        ${models.i_jepa_target_encoder.model.patch_size}
+        "}
+    kernel_size: 1
+    stride: null
+  model:
+    _target_: ami.models.bool_mask_i_jepa.BoolMaskIJEPAEncoder
+    img_size:
+      - ${shared.image_height} # Assuming 144
+      - ${shared.image_width} # Assuming 144
+    in_channels: ${shared.image_channels} # Assume 3
+    patch_size: 12
+    embed_dim: 216
+    out_dim: 32 # 1 / 13.5
+    depth: 6
+    num_heads: 3
+    mlp_ratio: 4.0
+
+i_jepa_context_encoder:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: False
+  model: ${..i_jepa_target_encoder.model}
+
+i_jepa_predictor:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: False
+  model:
+    _target_: ami.models.bool_mask_i_jepa.BoolTargetIJEPAPredictor
+    n_patches:
+      - >-
+        ${python.eval:"
+        ${shared.image_height} //
+        ${models.i_jepa_target_encoder.model.patch_size}
+        "}
+      - >-
+        ${python.eval:"
+        ${shared.image_width}
+        // ${models.i_jepa_target_encoder.model.patch_size}
+        "}
+    context_encoder_out_dim: ${models.i_jepa_target_encoder.model.out_dim}
+    hidden_dim: 108
+    depth: 6
+    num_heads: 2
+
+multimodal_temporal_encoder:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: True
+  inference_forward:
+    _target_: hydra.utils.get_method
+    path: ami.models.temporal_encoder.inference_forward
+  model:
+    _target_: ami.models.temporal_encoder.MultimodalTemporalEncoder
+    observation_flattens:
+      image:
+        _target_: ami.models.components.stacked_features.LerpStackedFeatures
+        dim_in: ${models.i_jepa_target_encoder.model.out_dim}
+        dim_out: 1024
+        num_stack: >-
+          ${python.eval:"
+          (${models.i_jepa_predictor.model.n_patches.0}
+          // ${models.i_jepa_target_encoder.inference_forward.kernel_size})
+          * (${models.i_jepa_predictor.model.n_patches.1}
+          // ${models.i_jepa_target_encoder.inference_forward.kernel_size})
+          "}
+    flattened_obses_projection:
+      _target_: torch.nn.Linear
+      in_features: >-
+        ${python.eval:"
+        ${..observation_flattens.image.dim_out}
+        "}
+      out_features: ${..core_model.dim}
+    core_model:
+      _target_: ami.models.components.sioconvps.SioConvPS
+      depth: 6
+      dim: 1024
+      dim_ff_hidden: ${python.eval:"${.dim} * 2"}
+      dropout: 0.1
+    obs_hat_dist_heads:
+      image:
+        _target_: torch.nn.Sequential
+        _args_:
+          - _target_: ami.models.components.stacked_features.ToStackedFeatures
+            dim_in: ${.....core_model.dim}
+            dim_out: ${models.i_jepa_target_encoder.model.out_dim}
+            num_stack: ${.....observation_flattens.image.num_stack}
+          - _target_: ami.models.components.fully_connected_fixed_std_normal.FullyConnectedFixedStdNormal
+            dim_in: ${..0.dim_out}
+            dim_out: ${models.i_jepa_target_encoder.model.out_dim}
+            normal_cls: Deterministic
+
+forward_dynamics:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: True
+  model:
+    _target_: ami.models.forward_dynamics.ForwardDynamcisWithActionReward
+    observation_flatten:
+      _target_: torch.nn.Identity
+    action_flatten:
+      _target_: ami.models.components.multi_embeddings.MultiEmbeddings
+      choices_per_category:
+        _target_: hydra.utils.get_object
+        path: ami.interactions.environments.actuators.vrchat_osc_discrete_actuator.ACTION_CHOICES_PER_CATEGORY
+      embedding_dim: 8
+      do_flatten: True
+    obs_action_projection:
+      _target_: torch.nn.Linear
+      # action_embedding_dim * num_action_choices + obs_embedding_dim
+      in_features: >-
+        ${python.eval:"
+        ${models.multimodal_temporal_encoder.model.core_model.dim}
+        + ${..action_flatten.embedding_dim} * 5
+        "}
+      out_features: ${..core_model.dim}
+    core_model:
+      _target_: ami.models.components.sioconvps.SioConvPS
+      depth: 6
+      dim: 1024
+      dim_ff_hidden: ${python.eval:"${.dim} * 2"}
+      dropout: 0.1
+    obs_hat_dist_head:
+      _target_: ami.models.components.fully_connected_fixed_std_normal.FullyConnectedFixedStdNormal
+      dim_in: ${..core_model.dim}
+      dim_out: ${models.multimodal_temporal_encoder.model.core_model.dim}
+      normal_cls: Deterministic
+    action_hat_dist_head:
+      _target_: ami.models.components.discrete_policy_head.DiscretePolicyHead
+      dim_in: ${..core_model.dim}
+      action_choices_per_category:
+        _target_: hydra.utils.get_object
+        path: ami.interactions.environments.actuators.vrchat_osc_discrete_actuator.ACTION_CHOICES_PER_CATEGORY
+    reward_hat_dist_head:
+      _target_: ami.models.components.fully_connected_normal.FullyConnectedNormal
+      dim_in: ${..core_model.dim}
+      dim_out: 1
+      squeeze_feature_dim: True
+
+policy_value:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: True
+  model:
+    _target_: ami.models.policy_value_common_net.PolicyValueCommonNet
+    observation_projection:
+      _target_: torch.nn.Linear
+      in_features: ${models.multimodal_temporal_encoder.model.core_model.dim}
+      out_features: ${..observation_hidden_projection.dim}
+    forward_dynamics_hidden_projection:
+      _target_: ami.models.components.stacked_hidden_state.StackwiseLinear
+      in_stacks: ${models.forward_dynamics.model.core_model.depth}
+      out_stacks: ${..observation_hidden_projection.depth}
+    observation_hidden_projection:
+      _target_: ami.models.components.sioconvps.SioConvPS
+      depth: 6
+      dim: 1024
+      dim_ff_hidden: ${python.eval:"${.dim} * 2"}
+      dropout: 0.1
+    core_model:
+      _target_: torch.nn.Identity
+    policy_head:
+      _target_: ami.models.components.discrete_policy_head.DiscretePolicyHead
+      dim_in: ${..observation_hidden_projection.dim}
+      action_choices_per_category:
+        _target_: hydra.utils.get_object
+        path: ami.interactions.environments.actuators.vrchat_osc_discrete_actuator.ACTION_CHOICES_PER_CATEGORY
+    value_head:
+      _target_: ami.models.components.fully_connected_value_head.FullyConnectedValueHead
+      dim_in: ${..observation_hidden_projection.dim}
+      squeeze_value_dim: True

--- a/configs/models/sioconv_policy/default.yaml
+++ b/configs/models/sioconv_policy/default.yaml
@@ -169,9 +169,14 @@ policy_value:
       in_features: ${models.multimodal_temporal_encoder.model.core_model.dim}
       out_features: ${..observation_hidden_projection.dim}
     forward_dynamics_hidden_projection:
-      _target_: ami.models.components.stacked_hidden_state.StackwiseLinear
-      in_stacks: ${models.forward_dynamics.model.core_model.depth}
-      out_stacks: ${..observation_hidden_projection.depth}
+      _target_: torch.nn.Sequential
+      _args_:
+        - _target_: ami.models.components.stacked_hidden_state.StackedHiddenSelection
+          in_stacks: ${models.forward_dynamics.model.core_model.depth}
+          out_stacks: ${....observation_hidden_projection.depth}
+        - _target_: torch.nn.Linear
+          in_features: ${models.forward_dynamics.model.core_model.dim}
+          out_features: ${....observation_hidden_projection.dim}
     observation_hidden_projection:
       _target_: ami.models.components.sioconvps.SioConvPS
       depth: 6

--- a/configs/models/sioconv_policy/default.yaml
+++ b/configs/models/sioconv_policy/default.yaml
@@ -178,8 +178,8 @@ policy_value:
       dim: 1024
       dim_ff_hidden: ${python.eval:"${.dim} * 2"}
       dropout: 0.1
-    core_model:
-      _target_: torch.nn.Identity
+    core_model: >- # Select SioConv output [0]
+      ${python.eval:"lambda x_hidden: x_hidden[0]"}
     policy_head:
       _target_: ami.models.components.discrete_policy_head.DiscretePolicyHead
       dim_in: ${..observation_hidden_projection.dim}

--- a/configs/models/sioconv_policy/default.yaml
+++ b/configs/models/sioconv_policy/default.yaml
@@ -70,7 +70,7 @@ multimodal_temporal_encoder:
   has_inference: True
   inference_forward:
     _target_: hydra.utils.get_method
-    path: ami.models.temporal_encoder.inference_forward
+    path: ami.models.temporal_encoder.inference_forward_with_layernorm
   model:
     _target_: ami.models.temporal_encoder.MultimodalTemporalEncoder
     observation_flattens:

--- a/configs/models/sioconv_policy/large.yaml
+++ b/configs/models/sioconv_policy/large.yaml
@@ -1,0 +1,36 @@
+# @package models
+
+defaults:
+  - sioconv_policy/default
+
+i_jepa_target_encoder:
+  model:
+    embed_dim: 432
+    num_heads: 6
+    out_dim: 128
+
+i_jepa_predictor:
+  model:
+    hidden_dim: 216
+    num_heads: 3
+
+multimodal_temporal_encoder:
+  model:
+    core_model:
+      depth: 16
+      dim: 1024
+      dim_ff_hidden: ${python.eval:"${.dim} * 4"}
+
+forward_dynamics:
+  model:
+    core_model:
+      depth: 20
+      dim: 1024
+      dim_ff_hidden: ${python.eval:"${.dim} * 4"}
+
+policy_value:
+  model:
+    observation_hidden_projection:
+      depth: 12
+      dim: 1024
+      dim_ff_hidden: ${python.eval:"${.dim} * 4"}

--- a/scripts/sioconv_policy/gamma-entropycoef-grid.sh
+++ b/scripts/sioconv_policy/gamma-entropycoef-grid.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Available task patterns
+declare -a tasks=("whitenoize" "blackout" "flickerimage")
+
+# Display available tasks
+echo "Available tasks:"
+for i in "${!tasks[@]}"; do
+    echo "  $i: ${tasks[$i]}"
+done
+
+# Get task selection from user
+while true; do
+    read -p "Select task number (0-$((${#tasks[@]}-1))): " task_num
+
+    # Validate input is a number
+    if ! [[ "$task_num" =~ ^[0-9]+$ ]]; then
+        echo "Please enter a valid number"
+        continue
+    fi
+
+    # Validate input is in range
+    if [ "$task_num" -lt 0 ] || [ "$task_num" -ge "${#tasks[@]}" ]; then
+        echo "Please enter a number between 0 and $((${#tasks[@]}-1))"
+        continue
+    fi
+
+    break
+done
+
+# Set task name from selection
+task_name="${tasks[$task_num]}"
+echo "Selected task: $task_name"
+
+# Define parameter arrays
+gamma_values=(0.9 0.97 0.991)
+entropy_coef_values=(0.1 0.04 0.016)
+
+# Outer loop for multiple runs
+for run in {1..3}; do
+    echo "Starting run $run of 3"
+
+    # Initialize grid pattern index
+    i=0
+
+    # Nested loops for parameter combinations
+    for gamma in "${gamma_values[@]}"; do
+        for entropy_coef in "${entropy_coef_values[@]}"; do
+            echo "Running with gamma=$gamma, entropy_coef=$entropy_coef (pattern $i)"
+
+            python scripts/launch.py \
+                experiment=sioconv_policy/${task_name} \
+                data_collectors.ppo_trajectory.gamma=$gamma \
+                trainers.ppo.entropy_coef=$entropy_coef \
+                time_scale=3.2 \
+                task_tag=entcoef_gamma_search/${i}
+
+            # Increment the pattern index
+            i=$((i + 1))
+        done
+    done
+done

--- a/tests/models/components/test_stacked_hidden_state.py
+++ b/tests/models/components/test_stacked_hidden_state.py
@@ -2,10 +2,7 @@ import pytest
 import torch
 
 from ami.models.components.sconv import SConv
-from ami.models.components.stacked_hidden_state import (
-    StackedHiddenSelection,
-    StackwiseLinear,
-)
+from ami.models.components.stacked_hidden_state import StackedHiddenSelection
 
 BATCH = 4
 DEPTH = 8
@@ -88,23 +85,4 @@ class TestStackedHiddenSelection:
     def test_forward(self, layer, input_shape, output_shape):
         hidden_stack = torch.randn(input_shape)
         out = layer(hidden_stack)
-        assert out.shape == output_shape
-
-
-class TestStackwiseLinear:
-    @pytest.fixture
-    def linear(self):
-        return StackwiseLinear(10, 8)
-
-    @pytest.mark.parametrize(
-        "input_shape,output_shape",
-        [
-            ((10, 16), (8, 16)),
-            ((2, 10, 32), (2, 8, 32)),
-            ((2, 3, 10, 16), (2, 3, 8, 16)),
-        ],
-    )
-    def test_forward(self, linear, input_shape, output_shape):
-        hidden_stack = torch.randn(input_shape)
-        out = linear(hidden_stack)
         assert out.shape == output_shape

--- a/tests/models/components/test_stacked_hidden_state.py
+++ b/tests/models/components/test_stacked_hidden_state.py
@@ -2,7 +2,10 @@ import pytest
 import torch
 
 from ami.models.components.sconv import SConv
-from ami.models.components.stacked_hidden_state import StackwiseLinear
+from ami.models.components.stacked_hidden_state import (
+    StackedHiddenSelection,
+    StackwiseLinear,
+)
 
 BATCH = 4
 DEPTH = 8
@@ -67,6 +70,25 @@ class TestStackedHiddenState:
         x, hidden = sconv(x, hidden[:, :, :, :, -1])
         assert x.shape == x_shape
         assert hidden.shape == hidden_shape
+
+
+class TestStackedHiddenSelection:
+    @pytest.fixture
+    def layer(self):
+        return StackedHiddenSelection(10, 8)
+
+    @pytest.mark.parametrize(
+        "input_shape,output_shape",
+        [
+            ((10, 16), (8, 16)),
+            ((2, 10, 32), (2, 8, 32)),
+            ((2, 3, 10, 16), (2, 3, 8, 16)),
+        ],
+    )
+    def test_forward(self, layer, input_shape, output_shape):
+        hidden_stack = torch.randn(input_shape)
+        out = layer(hidden_stack)
+        assert out.shape == output_shape
 
 
 class TestStackwiseLinear:

--- a/tests/models/components/test_stacked_hidden_state.py
+++ b/tests/models/components/test_stacked_hidden_state.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from ami.models.components.sconv import SConv
+from ami.models.components.stacked_hidden_state import StackwiseLinear
 
 BATCH = 4
 DEPTH = 8
@@ -66,3 +67,22 @@ class TestStackedHiddenState:
         x, hidden = sconv(x, hidden[:, :, :, :, -1])
         assert x.shape == x_shape
         assert hidden.shape == hidden_shape
+
+
+class TestStackwiseLinear:
+    @pytest.fixture
+    def linear(self):
+        return StackwiseLinear(10, 8)
+
+    @pytest.mark.parametrize(
+        "input_shape,output_shape",
+        [
+            ((10, 16), (8, 16)),
+            ((2, 10, 32), (2, 8, 32)),
+            ((2, 3, 10, 16), (2, 3, 8, 16)),
+        ],
+    )
+    def test_forward(self, linear, input_shape, output_shape):
+        hidden_stack = torch.randn(input_shape)
+        out = linear(hidden_stack)
+        assert out.shape == output_shape


### PR DESCRIPTION
## 概要

SioConvPSをPolicyに採用したConfigファイルを記述しました。

隠れ状態のdepth数がForward DynamicsとPolicyで異なっても良いようにするために、`StackwiseLinear`を新たに実装して用いました。

## レビューして欲しいファイル

* ami/models/components/stacked_hidden_state.py
* tests/models/components/test_stacked_hidden_state.py
* configs/models/sioconv_policy/default.yaml

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
