### PR TITLE
Nステップ先まで再帰的に想像する損失を実装した ImaginingForwardDynamicsTrainerを実装

### DIFF
--- a/ami/trainers/forward_dynamics_trainer.py
+++ b/ami/trainers/forward_dynamics_trainer.py
@@ -523,10 +523,13 @@ class ImaginingForwardDynamicsTrainer(BaseTrainer):
                     )
                     loss = -obses_next_hat_dist.log_prob(obs_targets).mean()
                     loss_imaginations.append(loss)
-                    obs_imaginations = obses_next_hat_dist.rsample().flatten(0, 1)  # (B, T-H, *) -> (B', *)
-                    hiddens = next_hiddens.movedim(2, 1).flatten(
-                        0, 1
-                    )  # h'_i, (B, D, T-H, *) -> (B, T-H, D, *) -> (B', D, *)
+                    obs_imaginations = obses_next_hat_dist.rsample()
+
+                    if i == 0:
+                        obs_imaginations = obs_imaginations.flatten(0, 1)  # (B, T-H, *) -> (B', *)
+                        hiddens = next_hiddens.movedim(2, 1).flatten(
+                            0, 1
+                        )  # h'_i, (B, D, T-H, *) -> (B, T-H, D, *) -> (B', D, *)
 
                 loss = self.imagination_average_method(torch.stack(loss_imaginations))
                 loss.backward()

--- a/ami/trainers/forward_dynamics_trainer.py
+++ b/ami/trainers/forward_dynamics_trainer.py
@@ -506,19 +506,19 @@ class ImaginingForwardDynamicsTrainer(BaseTrainer):
                 )
                 optimizer.zero_grad()
 
-                observations_next_hat_dist: Distribution
+                obses_next_hat_dist: Distribution
                 loss_imaginations: list[Tensor] = []
                 for i in range(self.imagination_length):
                     action_imaginations = actions[:, i : -self.imagination_length + i]  # a_i:i+T-H
                     obs_targets = observations[
                         :, i + 1 : observations.size(1) - self.imagination_length + i + 1
                     ]  # o_i+1:T-H+i+1
-                    observations_next_hat_dist, next_hiddens = self.forward_dynamics(
+                    obses_next_hat_dist, next_hiddens = self.forward_dynamics(
                         obs_imaginations, hiddens, action_imaginations
                     )
-                    loss = -observations_next_hat_dist.log_prob(obs_targets).mean()
+                    loss = -obses_next_hat_dist.log_prob(obs_targets).mean()
                     loss_imaginations.append(loss)
-                    observations = observations_next_hat_dist.rsample()
+                    obs_imaginations = obses_next_hat_dist.rsample()
                     hiddens = next_hiddens[:, :, 0]  # h'_i
 
                 loss = self.imagination_average_method(torch.stack(loss_imaginations))

--- a/ami/trainers/forward_dynamics_trainer.py
+++ b/ami/trainers/forward_dynamics_trainer.py
@@ -1,6 +1,7 @@
 import time
 from functools import partial
 from pathlib import Path
+from typing import Callable
 
 import torch
 from torch import Tensor
@@ -387,6 +388,146 @@ class PrimitiveForwardDynamicsTrainer(BaseTrainer):
                 self.logger.log(prefix + "loss", loss)
 
                 loss.backward()
+
+                grad_norm = grad_norm = torch.cat(
+                    [p.grad.flatten() for p in self.forward_dynamics.parameters() if p.grad is not None]
+                ).norm()
+                self.logger.log(prefix + "metrics/grad_norm", grad_norm)
+                optimizer.step()
+                self.logger.update()
+
+        self.optimizer_state = optimizer.state_dict()
+
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.optimizer_state, path / "optimizer.pt")
+        torch.save(self.logger.state_dict(), path / "logger.pt")
+        torch.save(self.dataset_previous_get_time, path / "dataset_previous_get_time.pt")
+
+    @override
+    def load_state(self, path: Path) -> None:
+        self.optimizer_state = torch.load(path / "optimizer.pt")
+        self.logger.load_state_dict(torch.load(path / "logger.pt"))
+        self.dataset_previous_get_time = torch.load(path / "dataset_previous_get_time.pt")
+
+
+class ImaginingForwardDynamicsTrainer(BaseTrainer):
+    def __init__(
+        self,
+        partial_dataloader: partial[DataLoader[torch.Tensor]],
+        partial_sampler: partial[RandomTimeSeriesSampler],
+        partial_optimizer: partial[Optimizer],
+        device: torch.device,
+        logger: StepIntervalLogger,
+        max_epochs: int = 1,
+        imagination_length: int = 1,
+        minimum_dataset_size: int = 2,
+        minimum_new_data_count: int = 0,
+        imagination_average_method: Callable[[Tensor], Tensor] = torch.mean,
+    ) -> None:
+        """Initialization.
+
+        Args:
+            partial_dataloader: A partially instantiated dataloader lacking a provided dataset.
+            partial_sampler: A partially instantiated sampler lacking a provided dataset.
+            partial_optimizer: A partially instantiated optimizer lacking provided parameters.
+            device: The accelerator device (e.g., CPU, GPU) utilized for training the model.
+            imagination_length: The length of imagination horizon.
+            minimum_dataset_size: Minimum number of dataset size to run the training.
+            minimum_new_data_count: Minimum number of new data count required to run the training.
+        """
+        super().__init__()
+        self.partial_optimizer = partial_optimizer
+        self.partial_dataloader = partial_dataloader
+        self.partial_sampler = partial_sampler
+        self.device = device
+        self.logger = logger
+        self.max_epochs = max_epochs
+        if imagination_length < 1:
+            raise ValueError("imagination_length must be larger than 0")
+        self.imagination_length = imagination_length
+        if minimum_dataset_size <= imagination_length:
+            raise ValueError("minimum_dataset_size must be larger than imagination_length.")
+        self.minimum_dataset_size = minimum_dataset_size
+        self.minimum_new_data_count = minimum_new_data_count
+        self.imagination_average_method = imagination_average_method
+
+        self.dataset_previous_get_time = float("-inf")
+
+    def on_data_users_dict_attached(self) -> None:
+        self.trajectory_data_user: ThreadSafeDataUser[CausalDataBuffer] = self.get_data_user(
+            BufferNames.FORWARD_DYNAMICS_TRAJECTORY
+        )
+
+    def on_model_wrappers_dict_attached(self) -> None:
+        self.forward_dynamics: ModelWrapper[ForwardDynamics] = self.get_training_model(ModelNames.FORWARD_DYNAMICS)
+        self.optimizer_state = self.partial_optimizer(self.forward_dynamics.parameters()).state_dict()
+
+    def is_trainable(self) -> bool:
+        self.trajectory_data_user.update()
+        return len(self.trajectory_data_user.buffer) >= self.minimum_dataset_size and self._is_new_data_available()
+
+    def _is_new_data_available(self) -> bool:
+        return (
+            self.trajectory_data_user.buffer.count_data_added_since(self.dataset_previous_get_time)
+            >= self.minimum_new_data_count
+        )
+
+    def get_dataset(self) -> Dataset[Tensor]:
+        dataset = self.trajectory_data_user.get_dataset()
+        self.dataset_previous_get_time = time.time()
+        return dataset
+
+    def train(self) -> None:
+        self.forward_dynamics.to(self.device)
+
+        optimizer = self.partial_optimizer(self.forward_dynamics.parameters())
+        optimizer.load_state_dict(self.optimizer_state)
+
+        dataset = self.get_dataset()
+        sampler = self.partial_sampler(dataset)
+        dataloader = self.partial_dataloader(dataset=dataset, sampler=sampler)
+
+        for _ in range(self.max_epochs):
+            batch: tuple[Tensor, ...]
+            for batch in dataloader:
+                observations, hiddens, actions = batch
+                if observations.shape[:2] != actions.shape[:2]:
+                    raise ValueError("The shape between observations and actions is not consistent!")
+                if observations.size(1) <= self.imagination_length:
+                    raise ValueError("Time length must be larger than imagination length!")
+
+                observations = observations.to(self.device)
+                actions = actions.to(self.device)
+                obs_imaginations, hiddens = (
+                    observations[:, : -self.imagination_length],  # o_0:T-H
+                    hiddens[:, 0].to(self.device),  # h_-1
+                )
+                optimizer.zero_grad()
+
+                observations_next_hat_dist: Distribution
+                loss_imaginations: list[Tensor] = []
+                for i in range(self.imagination_length):
+                    action_imaginations = actions[:, i : -self.imagination_length + i]  # a_i:i+T-H
+                    obs_targets = observations[
+                        :, i + 1 : observations.size(1) - self.imagination_length + i + 1
+                    ]  # o_i+1:T-H+i+1
+                    observations_next_hat_dist, next_hiddens = self.forward_dynamics(
+                        obs_imaginations, hiddens, action_imaginations
+                    )
+                    loss = -observations_next_hat_dist.log_prob(obs_targets).mean()
+                    loss_imaginations.append(loss)
+                    observations = observations_next_hat_dist.rsample()
+                    hiddens = next_hiddens[:, :, 0]  # h'_i
+
+                loss = self.imagination_average_method(torch.stack(loss_imaginations))
+                loss.backward()
+
+                prefix = "forward_dynamics/"
+                self.logger.log(prefix + "loss", loss)
+                for i, loss_item in enumerate(loss_imaginations, start=1):
+                    self.logger.log(prefix + f"loss/imagination_{i}", loss_item)
 
                 grad_norm = grad_norm = torch.cat(
                     [p.grad.flatten() for p in self.forward_dynamics.parameters() if p.grad is not None]

--- a/tests/trainers/test_forward_dynamics_trainer.py
+++ b/tests/trainers/test_forward_dynamics_trainer.py
@@ -519,13 +519,13 @@ class TestImaginingForwardDynamicsTrainer:
             }
         )
 
-        for _ in range(5):
+        for _ in range(10):
             d.collect(trajectory_step_data)
         return d
 
     @pytest.fixture
     def partial_dataloader(self):
-        return partial(DataLoader, batch_size=1, drop_last=True)
+        return partial(DataLoader, batch_size=2, drop_last=True)
 
     @pytest.fixture
     def partial_optimizer(self):
@@ -557,13 +557,13 @@ class TestImaginingForwardDynamicsTrainer:
     ):
         trainer = ImaginingForwardDynamicsTrainer(
             partial_dataloader,
-            partial(RandomTimeSeriesSampler, sequence_length=3 + 2),
+            partial(RandomTimeSeriesSampler, sequence_length=3 + 4),
             partial_optimizer,
             device,
             logger,
             minimum_new_data_count=2,
-            minimum_dataset_size=3 + 2,
-            imagination_length=2,
+            minimum_dataset_size=3 + 4,
+            imagination_length=4,
             imagination_average_method=torch.mean,
         )
         trainer.attach_model_wrappers_dict(forward_dynamics_wrappers_dict)

--- a/tests/trainers/test_forward_dynamics_trainer.py
+++ b/tests/trainers/test_forward_dynamics_trainer.py
@@ -14,6 +14,7 @@ from ami.models.components.fully_connected_fixed_std_normal import (
     FullyConnectedFixedStdNormal,
 )
 from ami.models.components.sconv import SConv
+from ami.models.components.sioconvps import SioConvPS
 from ami.models.forward_dynamics import (
     ForwardDynamcisWithActionReward,
     ForwardDynamics,
@@ -27,6 +28,7 @@ from ami.tensorboard_loggers import StepIntervalLogger
 from ami.trainers.forward_dynamics_trainer import (
     ForwardDynamicsTrainer,
     ForwardDynamicsWithActionRewardTrainer,
+    ImaginingForwardDynamicsTrainer,
     PrimitiveForwardDynamicsTrainer,
     RandomTimeSeriesSampler,
 )
@@ -463,6 +465,127 @@ class TestPrimitiveForwardDynamicsTrainer:
 
     def test_save_and_load_state(self, trainer: ForwardDynamicsWithActionRewardTrainer, tmp_path, mocker) -> None:
         trainer_path = tmp_path / "primitive_forward_dynamics"
+        trainer.save_state(trainer_path)
+        assert trainer_path.exists()
+        assert (trainer_path / "optimizer.pt").exists()
+        assert (trainer_path / "logger.pt").exists()
+        assert (trainer_path / "dataset_previous_get_time.pt").exists()
+        logger_state = trainer.logger.state_dict()
+        dataset_previous_get_time = trainer.dataset_previous_get_time
+
+        mocked_logger_load_state_dict = mocker.spy(trainer.logger, "load_state_dict")
+        trainer.optimizer_state.clear()
+        trainer.dataset_previous_get_time = None
+        assert trainer.optimizer_state == {}
+        trainer.load_state(trainer_path)
+        assert trainer.optimizer_state != {}
+        mocked_logger_load_state_dict.assert_called_once_with(logger_state)
+        assert trainer.dataset_previous_get_time == dataset_previous_get_time
+
+
+class TestImaginingForwardDynamicsTrainer:
+    @pytest.fixture
+    def forward_dynamics(
+        self,
+    ):
+        return ForwardDynamics(
+            observation_flatten=nn.Identity(),
+            action_flatten=nn.Identity(),
+            obs_action_projection=nn.Linear(DIM_OBS + DIM_ACTION, DIM),
+            core_model=SioConvPS(DEPTH, DIM, DIM_FF_HIDDEN, 0.1),
+            obs_hat_dist_head=FullyConnectedFixedStdNormal(DIM, DIM_OBS),
+        )
+
+    @pytest.fixture
+    def trajectory_step_data(self) -> StepData:
+        d = StepData()
+        d[DataKeys.OBSERVATION] = torch.randn(DIM_OBS)
+        d[DataKeys.HIDDEN] = torch.randn(DEPTH, DIM)
+        d[DataKeys.ACTION] = torch.randn(DIM_ACTION)
+        return d
+
+    @pytest.fixture
+    def trajectory_buffer_dict(self, trajectory_step_data: StepData) -> DataCollectorsDict:
+        d = DataCollectorsDict.from_data_buffers(
+            **{
+                BufferNames.FORWARD_DYNAMICS_TRAJECTORY: CausalDataBuffer.reconstructable_init(
+                    32,
+                    [
+                        DataKeys.OBSERVATION,
+                        DataKeys.HIDDEN,
+                        DataKeys.ACTION,
+                    ],
+                )
+            }
+        )
+
+        for _ in range(5):
+            d.collect(trajectory_step_data)
+        return d
+
+    @pytest.fixture
+    def partial_dataloader(self):
+        return partial(DataLoader, batch_size=1, drop_last=True)
+
+    @pytest.fixture
+    def partial_optimizer(self):
+        return partial(Adam, lr=0.001)
+
+    @pytest.fixture
+    def forward_dynamics_wrappers_dict(self, forward_dynamics, device):
+        d = ModelWrappersDict(
+            {
+                ModelNames.FORWARD_DYNAMICS: ModelWrapper(forward_dynamics, device, True),
+            }
+        )
+        d.send_to_default_device()
+        return d
+
+    @pytest.fixture
+    def logger(self, tmp_path):
+        return StepIntervalLogger(f"{tmp_path}/tensorboard", 1)
+
+    @pytest.fixture
+    def trainer(
+        self,
+        partial_dataloader,
+        partial_optimizer,
+        device,
+        forward_dynamics_wrappers_dict,
+        trajectory_buffer_dict,
+        logger,
+    ):
+        trainer = ImaginingForwardDynamicsTrainer(
+            partial_dataloader,
+            partial(RandomTimeSeriesSampler, sequence_length=3 + 2),
+            partial_optimizer,
+            device,
+            logger,
+            minimum_new_data_count=2,
+            minimum_dataset_size=3 + 2,
+            imagination_length=2,
+            imagination_average_method=torch.mean,
+        )
+        trainer.attach_model_wrappers_dict(forward_dynamics_wrappers_dict)
+        trainer.attach_data_users_dict(trajectory_buffer_dict.get_data_users())
+        return trainer
+
+    def test_run(self, trainer) -> None:
+        trainer.run()
+
+    def test_is_trainable(self, trainer) -> None:
+        assert trainer.is_trainable() is True
+        trainer.trajectory_data_user.clear()
+        assert trainer.is_trainable() is False
+
+    def test_is_new_data_available(self, trainer: ForwardDynamicsWithActionRewardTrainer):
+        trainer.trajectory_data_user.update()
+        assert trainer._is_new_data_available() is True
+        trainer.run()
+        assert trainer._is_new_data_available() is False
+
+    def test_save_and_load_state(self, trainer: ForwardDynamicsWithActionRewardTrainer, tmp_path, mocker) -> None:
+        trainer_path = tmp_path / "forward_dynamics_with_action_reward"
         trainer.save_state(trainer_path)
         assert trainer_path.exists()
         assert (trainer_path / "optimizer.pt").exists()


### PR DESCRIPTION
## 概要

Nステップ先まで再帰的に想像し、より長期予測を可能にするための損失を実装した ImaginingForwardDynamicsTrainerを実装しました。

主に `train`メソッドの中身を確認していただけるとありがたいです。
もう少し説明が必要であればコメントお願いします。

### 参考

https://github.com/MLShukai/ami-theory/blob/main/dist/long_span_prediction_reward.pdf


## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
