### PR TITLE
PolicyとForward Dynamicsで 隠れ状態を独立にもつCuriosityAgentクラスを実装

### DIFF
--- a/ami/interactions/agents/curiosity_agent.py
+++ b/ami/interactions/agents/curiosity_agent.py
@@ -10,6 +10,7 @@ from ami.data.buffers.buffer_names import BufferNames
 from ami.data.step_data import DataKeys, StepData
 from ami.models.forward_dynamics import (
     ForwardDynamcisWithActionReward,
+    ForwardDynamics,
     PrimitiveForwardDynamics,
 )
 from ami.models.model_names import ModelNames
@@ -17,6 +18,7 @@ from ami.models.model_wrapper import ThreadSafeInferenceWrapper
 from ami.models.policy_value_common_net import (
     PolicyValueCommonNet,
     PrimitivePolicyValueCommonNet,
+    TemporalPolicyValueCommonNet,
 )
 from ami.tensorboard_loggers import TimeIntervalLogger
 
@@ -284,4 +286,169 @@ class PrimitiveCuriosityAgent(BaseAgent[Tensor, Tensor]):
 
     @override
     def load_state(self, path: Path) -> None:
+        self.logger.load_state_dict(torch.load(path / "logger.pt"))
+
+
+class SeparatedHiddenCuriosityAgent(BaseAgent[Tensor, Tensor]):
+    """A reinforcement learning agent that uses curiosity-driven exploration
+    through forward dynamics prediction.
+
+    This agent implements curiosity-driven exploration by predicting
+    future observations and using prediction errors as intrinsic
+    rewards. It maintains a forward dynamics model to predict future
+    states and a policy-value network for action selection.
+    """
+
+    @override
+    def __init__(
+        self,
+        initial_forward_dynamics_hidden: Tensor,
+        initial_policy_hidden: Tensor,
+        logger: TimeIntervalLogger,
+        max_imagination_steps: int = 1,
+        reward_average_method: Callable[[Tensor], Tensor] = torch.mean,
+    ) -> None:
+        """Initializes the CuriosityAgent.
+
+        Args:
+            initial_hidden (Tensor): Initial hidden state tensor for the forward dynamics model.
+            logger (TimeIntervalLogger): Logger instance for recording metrics and rewards.
+            max_imagination_steps (int, optional): Maximum number of steps to imagine into the future. Must be >= 1. Defaults to 1.
+            reward_average_method (Callable[[Tensor], Tensor], optional): Function to average rewards across imagination steps.
+                Takes a tensor of rewards (imagination_steps,) and returns a scalar reward. Defaults to torch.mean.
+        """
+        super().__init__()
+        if max_imagination_steps < 1:
+            raise ValueError(f"`max_imagination_steps` must be >= 1! Your input: {max_imagination_steps}")
+
+        self.head_forward_dynamics_hidden_state = initial_forward_dynamics_hidden
+        self.policy_hidden_state = initial_policy_hidden
+        self.logger = logger
+        self.max_imagination_steps = max_imagination_steps
+        self.reward_average_method = reward_average_method
+
+    @override
+    def on_inference_models_attached(self) -> None:
+        super().on_inference_models_attached()
+        self.forward_dynamics: ThreadSafeInferenceWrapper[ForwardDynamics] = self.get_inference_model(
+            ModelNames.FORWARD_DYNAMICS
+        )
+        self.policy_value: ThreadSafeInferenceWrapper[TemporalPolicyValueCommonNet] = self.get_inference_model(
+            ModelNames.POLICY_VALUE
+        )
+
+    @override
+    def on_data_collectors_attached(self) -> None:
+        super().on_data_collectors_attached()
+        self.forward_dynamics_collector = self.get_data_collector(
+            BufferNames.FORWARD_DYNAMICS_TRAJECTORY,
+        )
+        self.policy_collector = self.get_data_collector(
+            BufferNames.PPO_TRAJECTORY,
+        )
+
+    # ###### INTERACTION PROCESS ########
+
+    head_forward_dynamics_hidden_state: Tensor  # (depth, dim)
+    policy_hidden_state: Tensor  # (depth, dim)
+    obs_dist_imaginations: Distribution  # (imaginations, dim)
+    obs_imaginations: Tensor  # (imaginations, dim)
+    forward_dynamics_hidden_imaginations: Tensor  # (imaginations, depth, dim)
+    step_data_fd: StepData
+    step_data_policy: StepData
+
+    @override
+    def setup(self) -> None:
+        super().setup()
+        self.step_data_fd, self.step_data_policy = StepData(), StepData()
+        self.forward_dynamics_hidden_imaginations = torch.empty(0).type_as(self.head_forward_dynamics_hidden_state)
+        self.obs_imaginations = torch.empty(0, device=self.forward_dynamics_hidden_imaginations.device)
+        self.initial_step = True
+
+    @override
+    def step(self, observation: Tensor) -> Tensor:
+        action = self._common_step(observation, self.initial_step)
+        self.initial_step = False
+        return action
+
+    def _common_step(self, observation: Tensor, initial_step: bool) -> Tensor:
+        """Executes the common step procedure for the curiosity-driven agent.
+
+        Args:
+            observation (Tensor): Current observation from the environment
+            initial_step (bool): Whether this is the first step in an episode.
+                When True, skips reward calculation as there are no previous predictions.
+
+        Returns:
+            Tensor: Selected action to be executed in the environment
+        """
+        observation = observation.type_as(self.obs_imaginations)  # convert type and send to device
+
+        if not initial_step:
+            target_obses = observation.expand_as(self.obs_imaginations)
+            reward_imaginations = -self.obs_dist_imaginations.log_prob(target_obses).flatten(1).mean(-1)
+
+            reward = self.reward_average_method(reward_imaginations)
+            self.logger.log("curiosity_agent/reward", reward)
+
+            self.step_data_policy[DataKeys.REWARD] = reward
+            self.policy_collector.collect(self.step_data_policy)
+
+        obs_imaginations = torch.cat([observation[None], self.obs_imaginations])[
+            : self.max_imagination_steps
+        ]  # (imaginations, dim)
+        hidden_imaginations = torch.cat(
+            [self.head_forward_dynamics_hidden_state[None], self.forward_dynamics_hidden_imaginations]
+        )[
+            : self.max_imagination_steps
+        ]  # (imaginations, depth, dim)
+
+        action_dist: Distribution
+        value: Tensor
+        action_dist, value, policy_hidden_state = self.policy_value(obs_imaginations[0], hidden_imaginations[0])
+        action = action_dist.sample()
+        action_log_prob = action_dist.log_prob(action)
+
+        self.step_data_fd[DataKeys.HIDDEN] = self.head_forward_dynamics_hidden_state
+
+        obs_dist_imaginations, hidden_imaginations = self.forward_dynamics(
+            obs_imaginations, hidden_imaginations, action.expand((len(obs_imaginations), *action.shape))
+        )
+        obs_imaginations = obs_dist_imaginations.sample()
+
+        self.step_data_fd[DataKeys.OBSERVATION] = self.step_data_policy[DataKeys.OBSERVATION] = observation.cpu()
+        self.step_data_fd[DataKeys.ACTION] = self.step_data_policy[DataKeys.ACTION] = action
+        self.forward_dynamics_collector.collect(self.step_data)
+
+        self.step_data_policy[DataKeys.ACTION_LOG_PROBABILITY] = action_log_prob
+        self.step_data_policy[DataKeys.VALUE] = value
+        self.step_data_policy[DataKeys.HIDDEN] = self.policy_hidden_state
+        self.logger.log("curiosity_agent/value", value)
+
+        self.obs_dist_imaginations = obs_dist_imaginations
+        self.obs_imaginations = obs_imaginations
+        self.forward_dynamics_hidden_imaginations = hidden_imaginations
+        self.head_forward_dynamics_hidden_state = hidden_imaginations[0]
+        self.policy_hidden_state = policy_hidden_state
+
+        self.logger.update()
+        return action
+
+    # ###### State saving ######
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.head_forward_dynamics_hidden_state, path / "head_forward_dynamics_hidden_state.pt")
+        torch.save(self.policy_hidden_state, "policy_hidden_state.pt")
+        torch.save(self.logger.state_dict(), path / "logger.pt")
+
+    @override
+    def load_state(self, path: Path) -> None:
+        self.head_forward_dynamics_hidden_state = torch.load(
+            path / "head_forward_dynamics_hidden_state.pt",
+            map_location=self.head_forward_dynamics_hidden_state.device,
+        )
+        self.policy_hidden_state = torch.load(
+            path / "policy_hidden_state.pt", map_location=self.policy_hidden_state.device
+        )
         self.logger.load_state_dict(torch.load(path / "logger.pt"))

--- a/ami/interactions/agents/curiosity_agent.py
+++ b/ami/interactions/agents/curiosity_agent.py
@@ -403,6 +403,7 @@ class SeparatedHiddenCuriosityAgent(BaseAgent[Tensor, Tensor]):
             : self.max_imagination_steps
         ]  # (imaginations, depth, dim)
 
+        self.step_data_policy[DataKeys.HIDDEN] = self.policy_hidden_state
         action_dist: Distribution
         value: Tensor
         action_dist, value, policy_hidden_state = self.policy_value(obs_imaginations[0], hidden_imaginations[0])
@@ -418,11 +419,10 @@ class SeparatedHiddenCuriosityAgent(BaseAgent[Tensor, Tensor]):
 
         self.step_data_fd[DataKeys.OBSERVATION] = self.step_data_policy[DataKeys.OBSERVATION] = observation.cpu()
         self.step_data_fd[DataKeys.ACTION] = self.step_data_policy[DataKeys.ACTION] = action
-        self.forward_dynamics_collector.collect(self.step_data)
+        self.forward_dynamics_collector.collect(self.step_data_fd)
 
         self.step_data_policy[DataKeys.ACTION_LOG_PROBABILITY] = action_log_prob
         self.step_data_policy[DataKeys.VALUE] = value
-        self.step_data_policy[DataKeys.HIDDEN] = self.policy_hidden_state
         self.logger.log("curiosity_agent/value", value)
 
         self.obs_dist_imaginations = obs_dist_imaginations
@@ -439,7 +439,7 @@ class SeparatedHiddenCuriosityAgent(BaseAgent[Tensor, Tensor]):
     def save_state(self, path: Path) -> None:
         path.mkdir()
         torch.save(self.head_forward_dynamics_hidden_state, path / "head_forward_dynamics_hidden_state.pt")
-        torch.save(self.policy_hidden_state, "policy_hidden_state.pt")
+        torch.save(self.policy_hidden_state, path / "policy_hidden_state.pt")
         torch.save(self.logger.state_dict(), path / "logger.pt")
 
     @override

--- a/ami/interactions/agents/curiosity_agent.py
+++ b/ami/interactions/agents/curiosity_agent.py
@@ -289,7 +289,7 @@ class PrimitiveCuriosityAgent(BaseAgent[Tensor, Tensor]):
         self.logger.load_state_dict(torch.load(path / "logger.pt"))
 
 
-class SeparatedHiddenCuriosityAgent(BaseAgent[Tensor, Tensor]):
+class IsolatedHiddenCuriosityAgent(BaseAgent[Tensor, Tensor]):
     """A reinforcement learning agent that uses curiosity-driven exploration
     through forward dynamics prediction.
 

--- a/tests/interactions/agents/test_curiosity_agent.py
+++ b/tests/interactions/agents/test_curiosity_agent.py
@@ -10,12 +10,14 @@ from ami.data.utils import DataCollectorsDict
 from ami.interactions.agents.curiosity_agent import (
     CuriosityAgent,
     PrimitiveCuriosityAgent,
+    SeparatedHiddenCuriosityAgent,
 )
 from ami.models.components.fully_connected_normal import FullyConnectedNormal
 from ami.models.components.fully_connected_value_head import FullyConnectedValueHead
 from ami.models.components.sioconv import SioConv
 from ami.models.forward_dynamics import (
     ForwardDynamcisWithActionReward,
+    ForwardDynamics,
     PrimitiveForwardDynamics,
 )
 from ami.models.model_names import ModelNames
@@ -24,6 +26,7 @@ from ami.models.policy_value_common_net import (
     PolicyValueCommonNet,
     PrimitivePolicyValueCommonNet,
     SelectObservation,
+    TemporalPolicyValueCommonNet,
 )
 from ami.models.utils import InferenceWrappersDict, ModelWrapper, ModelWrappersDict
 from ami.tensorboard_loggers import TimeIntervalLogger
@@ -279,3 +282,125 @@ class TestPrimitiveCuriosityAgent:
         # Load state and verify it's restored
         agent.load_state(agent_path)
         assert agent.logger.state_dict() == logger_state
+
+
+class TestSeparatedHiddenCuriosityAgent:
+    @pytest.fixture
+    def models(self, device) -> ModelWrappersDict:
+        # Create forward dynamics model
+        forward_dynamics = ForwardDynamics(
+            nn.Identity(),
+            nn.Identity(),
+            nn.Linear(OBSERVATION_DIM + ACTION_DIM, HIDDEN_DIM),
+            SioConv(DEPTH, HIDDEN_DIM, HEAD, HIDDEN_DIM, 0.1, 16),
+            FullyConnectedNormal(HIDDEN_DIM, OBSERVATION_DIM),
+        )
+
+        policy_value = TemporalPolicyValueCommonNet(
+            observation_flatten=nn.Linear(OBSERVATION_DIM, HIDDEN_DIM),
+            core_model=SioConv(DEPTH, HIDDEN_DIM, HEAD, HIDDEN_DIM, 0.1, 16),
+            policy_head=FullyConnectedNormal(HIDDEN_DIM, ACTION_DIM),
+            value_head=FullyConnectedValueHead(HIDDEN_DIM, squeeze_value_dim=True),
+        )
+
+        return {
+            ModelNames.FORWARD_DYNAMICS: ModelWrapper(forward_dynamics, device, True),
+            ModelNames.POLICY_VALUE: ModelWrapper(policy_value, device, True),
+        }
+
+    @pytest.fixture
+    def inference_models(self, models) -> InferenceWrappersDict:
+        mwd = ModelWrappersDict(models)
+        mwd.send_to_default_device()
+
+        return mwd.inference_wrappers_dict
+
+    @pytest.fixture
+    def data_collectors(self) -> DataCollectorsDict:
+        empty_buffer = RandomDataBuffer(10, [DataKeys.OBSERVATION])
+        return DataCollectorsDict.from_data_buffers(
+            **{
+                BufferNames.FORWARD_DYNAMICS_TRAJECTORY: empty_buffer,
+                BufferNames.PPO_TRAJECTORY: empty_buffer,
+            }
+        )
+
+    @pytest.fixture
+    def logger(self, tmp_path):
+        return TimeIntervalLogger(f"{tmp_path}/tensorboard", 0)
+
+    @pytest.fixture
+    def agent(self, inference_models, data_collectors, logger, device) -> SeparatedHiddenCuriosityAgent:
+        curiosity_agent = SeparatedHiddenCuriosityAgent(
+            initial_forward_dynamics_hidden=torch.zeros(DEPTH, HIDDEN_DIM, device=device),
+            initial_policy_hidden=torch.zeros(DEPTH, HIDDEN_DIM, device=device),
+            logger=logger,
+            max_imagination_steps=3,
+        )
+        curiosity_agent.attach_data_collectors(data_collectors)
+        curiosity_agent.attach_inference_models(inference_models)
+        return curiosity_agent
+
+    def test_setup_step_teardown(self, agent: SeparatedHiddenCuriosityAgent):
+        """Test the main interaction loop of the agent."""
+        observation = torch.randn(OBSERVATION_DIM)
+        agent.setup()
+
+        assert agent.initial_step
+        for _ in range(10):
+            action = agent.step(observation)
+            assert not agent.initial_step
+            assert action.shape == (ACTION_DIM,)
+            assert isinstance(action, torch.Tensor)
+
+        # Check step data shapes
+        assert agent.step_data_fd[DataKeys.OBSERVATION].shape == (OBSERVATION_DIM,)
+        assert agent.step_data_fd[DataKeys.ACTION].shape == (ACTION_DIM,)
+        assert agent.step_data_fd[DataKeys.HIDDEN].shape == (DEPTH, HIDDEN_DIM)
+
+        assert agent.step_data_policy[DataKeys.OBSERVATION].shape == (OBSERVATION_DIM,)
+        assert agent.step_data_policy[DataKeys.ACTION].shape == (ACTION_DIM,)
+        assert agent.step_data_policy[DataKeys.ACTION_LOG_PROBABILITY].shape == (ACTION_DIM,)
+        assert agent.step_data_policy[DataKeys.VALUE].shape == ()
+        assert agent.step_data_policy[DataKeys.HIDDEN].shape == (DEPTH, HIDDEN_DIM)
+        assert agent.step_data_policy[DataKeys.REWARD].shape == ()
+
+        assert not torch.allclose(agent.step_data_fd[DataKeys.HIDDEN], agent.step_data_policy[DataKeys.HIDDEN])
+
+        # Check imagination states
+        assert isinstance(agent.obs_dist_imaginations, Distribution)
+        assert len(agent.obs_imaginations) == 3
+        assert isinstance(agent.obs_imaginations, torch.Tensor)
+        assert len(agent.forward_dynamics_hidden_imaginations) == 3
+        assert isinstance(agent.forward_dynamics_hidden_imaginations, torch.Tensor)
+
+    def test_save_and_load_state(self, agent: SeparatedHiddenCuriosityAgent, tmp_path):
+        """Test state saving and loading functionality."""
+        agent_path = tmp_path / "agent"
+        agent.save_state(agent_path)
+        assert (agent_path / "head_forward_dynamics_hidden_state.pt").exists()
+        assert (agent_path / "policy_hidden_state.pt").exists()
+
+        # Modify state and verify it's different
+        fd_hidden = agent.head_forward_dynamics_hidden_state.clone()
+        policy_hidden = agent.policy_hidden_state.clone()
+
+        agent.head_forward_dynamics_hidden_state = torch.randn_like(fd_hidden)
+        agent.policy_hidden_state = torch.randn_like(policy_hidden)
+        assert not torch.equal(agent.head_forward_dynamics_hidden_state, fd_hidden)
+        assert not torch.equal(agent.policy_hidden_state, policy_hidden)
+
+        # Load state and verify it's restored
+        agent.load_state(agent_path)
+        assert torch.equal(agent.head_forward_dynamics_hidden_state, fd_hidden)
+        assert torch.equal(agent.policy_hidden_state, policy_hidden)
+
+    def test_initialization_with_invalid_steps(self, logger):
+        """Test that agent raises error for invalid max_imagination_steps."""
+        with pytest.raises(ValueError):
+            SeparatedHiddenCuriosityAgent(
+                initial_forward_dynamics_hidden=torch.zeros(DEPTH, HIDDEN_DIM),
+                initial_policy_hidden=torch.zeros(DEPTH, HIDDEN_DIM),
+                logger=logger,
+                max_imagination_steps=0,
+            )

--- a/tests/interactions/agents/test_curiosity_agent.py
+++ b/tests/interactions/agents/test_curiosity_agent.py
@@ -9,8 +9,8 @@ from ami.data.step_data import DataKeys
 from ami.data.utils import DataCollectorsDict
 from ami.interactions.agents.curiosity_agent import (
     CuriosityAgent,
+    IsolatedHiddenCuriosityAgent,
     PrimitiveCuriosityAgent,
-    SeparatedHiddenCuriosityAgent,
 )
 from ami.models.components.fully_connected_normal import FullyConnectedNormal
 from ami.models.components.fully_connected_value_head import FullyConnectedValueHead
@@ -284,7 +284,7 @@ class TestPrimitiveCuriosityAgent:
         assert agent.logger.state_dict() == logger_state
 
 
-class TestSeparatedHiddenCuriosityAgent:
+class TestIsolatedHiddenCuriosityAgent:
     @pytest.fixture
     def models(self, device) -> ModelWrappersDict:
         # Create forward dynamics model
@@ -330,8 +330,8 @@ class TestSeparatedHiddenCuriosityAgent:
         return TimeIntervalLogger(f"{tmp_path}/tensorboard", 0)
 
     @pytest.fixture
-    def agent(self, inference_models, data_collectors, logger, device) -> SeparatedHiddenCuriosityAgent:
-        curiosity_agent = SeparatedHiddenCuriosityAgent(
+    def agent(self, inference_models, data_collectors, logger, device) -> IsolatedHiddenCuriosityAgent:
+        curiosity_agent = IsolatedHiddenCuriosityAgent(
             initial_forward_dynamics_hidden=torch.zeros(DEPTH, HIDDEN_DIM, device=device),
             initial_policy_hidden=torch.zeros(DEPTH, HIDDEN_DIM, device=device),
             logger=logger,
@@ -341,7 +341,7 @@ class TestSeparatedHiddenCuriosityAgent:
         curiosity_agent.attach_inference_models(inference_models)
         return curiosity_agent
 
-    def test_setup_step_teardown(self, agent: SeparatedHiddenCuriosityAgent):
+    def test_setup_step_teardown(self, agent: IsolatedHiddenCuriosityAgent):
         """Test the main interaction loop of the agent."""
         observation = torch.randn(OBSERVATION_DIM)
         agent.setup()
@@ -374,7 +374,7 @@ class TestSeparatedHiddenCuriosityAgent:
         assert len(agent.forward_dynamics_hidden_imaginations) == 3
         assert isinstance(agent.forward_dynamics_hidden_imaginations, torch.Tensor)
 
-    def test_save_and_load_state(self, agent: SeparatedHiddenCuriosityAgent, tmp_path):
+    def test_save_and_load_state(self, agent: IsolatedHiddenCuriosityAgent, tmp_path):
         """Test state saving and loading functionality."""
         agent_path = tmp_path / "agent"
         agent.save_state(agent_path)
@@ -398,7 +398,7 @@ class TestSeparatedHiddenCuriosityAgent:
     def test_initialization_with_invalid_steps(self, logger):
         """Test that agent raises error for invalid max_imagination_steps."""
         with pytest.raises(ValueError):
-            SeparatedHiddenCuriosityAgent(
+            IsolatedHiddenCuriosityAgent(
                 initial_forward_dynamics_hidden=torch.zeros(DEPTH, HIDDEN_DIM),
                 initial_policy_hidden=torch.zeros(DEPTH, HIDDEN_DIM),
                 logger=logger,


### PR DESCRIPTION
## 概要

PolicyとForward Dynamicsの隠れ状態をそれぞれで独立に管理するCuriosityAgentクラスを実装しました。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
