### PR TITLE
テスト時の量子化誤差を減らすため浮動小数点PCMを使用

### DIFF
--- a/tests/trainers/components/test_auditory.py
+++ b/tests/trainers/components/test_auditory.py
@@ -15,6 +15,7 @@ OUTPUT_SAMPLE_RATE = 16000
 NUM_ORIGINAL_AUDIOS = 10
 NUM_SELECT = 5
 INTERVAL = max(NUM_ORIGINAL_AUDIOS // NUM_SELECT, 1)
+ALLCLOSE_ATOL = 1e-4
 
 
 class TestIntervalSamplingAudioDataset:
@@ -52,7 +53,6 @@ class TestIntervalSamplingAudioDataset:
                 uri=str(audio_dir / f"original_audio_{i}.wav"),
                 src=original_audio,
                 sample_rate=ORIGINAL_SAMPLE_RATE,
-                encoding="PCM_F",
             )
         return audio_dir
 
@@ -83,7 +83,7 @@ class TestIntervalSamplingAudioDataset:
             assert isinstance(item, tuple)
             assert len(item) == 1
             assert item[0].shape == expected_audio.shape
-            assert torch.allclose(item[0], expected_audio)
+            assert torch.allclose(item[0], expected_audio, atol=ALLCLOSE_ATOL)
 
     def test_pre_loading(self, original_audio_dir, expected_audios):
         dataset = IntervalSamplingAudioDataset(
@@ -97,7 +97,7 @@ class TestIntervalSamplingAudioDataset:
         assert len(dataset.audio_data) == NUM_SELECT
         assert len(dataset.audio_data) == len(expected_audios)
         assert all(
-            torch.allclose(output_audio, expected_audio)
+            torch.allclose(output_audio, expected_audio, atol=ALLCLOSE_ATOL)
             for output_audio, expected_audio in zip(dataset.audio_data, expected_audios)
         )
 
@@ -111,4 +111,4 @@ class TestIntervalSamplingAudioDataset:
         )
         assert dataset.audio_data is None
         assert len(dataset) == len(expected_audios)
-        assert all(torch.allclose(dataset[i][0], expected_audios[i]) for i in range(len(dataset)))
+        assert all(torch.allclose(dataset[i][0], expected_audios[i], atol=ALLCLOSE_ATOL) for i in range(len(dataset)))

--- a/tests/trainers/components/test_auditory.py
+++ b/tests/trainers/components/test_auditory.py
@@ -52,6 +52,7 @@ class TestIntervalSamplingAudioDataset:
                 uri=str(audio_dir / f"original_audio_{i}.wav"),
                 src=original_audio,
                 sample_rate=ORIGINAL_SAMPLE_RATE,
+                encoding="PCM_F",
             )
         return audio_dir
 


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
自分の環境だと量子化誤差が原因で`allclose`が弾かれるようでした

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
`save`時の`encoding`を`PCM_F`に変更

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
